### PR TITLE
Add user playcount to artist pages (#25)

### DIFF
--- a/apps/web/src/api/internal/artist.ts
+++ b/apps/web/src/api/internal/artist.ts
@@ -24,6 +24,7 @@ app.get('/artist-summary', async (c) => {
 
 app.get('/artist-lastfm', async (c) => {
   const name = c.req.query('name');
+  const username = c.req.query('username');
 
   if (!name) {
     return c.json({ error: 'Missing name parameter' }, 400);
@@ -33,7 +34,7 @@ app.get('/artist-lastfm', async (c) => {
     const lastfm = c.get('lastfm');
     // Fetch artist detail and top albums in parallel
     const [artistDetail, topAlbums] = await Promise.all([
-      lastfm.getArtistDetail(name),
+      lastfm.getArtistDetail(name, username || undefined),
       lastfm.getArtistTopAlbums(name, 3),
     ]);
     return c.json({

--- a/apps/web/src/pages/artist/detail.tsx
+++ b/apps/web/src/pages/artist/detail.tsx
@@ -78,6 +78,9 @@ export function ArtistDetailPage({
                 <span class="text-muted">Loading...</span>
               </p>
 
+              {/* User playcount - populated via JS for logged-in users */}
+              <p id="user-playcount" style={{ display: 'none' }}></p>
+
               {/* Popular Albums - loaded via JS from Last.fm */}
               <div id="popular-albums">
                 <p style={{ marginBottom: '0.2em' }}>
@@ -107,6 +110,7 @@ export function ArtistDetailPage({
         (function() {
           var artistName = ${JSON.stringify(artist.name)};
           var artistId = '${artist.id}';
+          var lastfmUsername = ${currentUser?.lastfm_username ? JSON.stringify(currentUser.lastfm_username) : 'null'};
 
           // Tags to filter out (not real genres)
           var excludedTags = ['seen live', 'live', 'favorite', 'favorites', 'favourite', 'favourites',
@@ -119,7 +123,11 @@ export function ArtistDetailPage({
           }
 
           // Fetch Last.fm data (playcount, genres, and similar artists)
-          internalFetch('/api/internal/artist-lastfm?name=' + encodeURIComponent(artistName), { cache: 'no-store' })
+          var lastfmUrl = '/api/internal/artist-lastfm?name=' + encodeURIComponent(artistName);
+          if (lastfmUsername) {
+            lastfmUrl += '&username=' + encodeURIComponent(lastfmUsername);
+          }
+          internalFetch(lastfmUrl, { cache: 'no-store' })
             .then(function(r) {
               if (!r.ok) throw new Error('HTTP ' + r.status);
               return r.json();
@@ -143,6 +151,13 @@ export function ArtistDetailPage({
                 }
               } else {
                 document.getElementById('genre-section').innerHTML = '<strong>Genre:</strong> Unknown';
+              }
+
+              // Show user playcount if available
+              if (lastfmUsername && lastfm.userplaycount !== undefined) {
+                var el = document.getElementById('user-playcount');
+                el.innerHTML = '<strong>Your plays:</strong> ' + lastfm.userplaycount.toLocaleString();
+                el.style.display = '';
               }
 
               // Update popular albums (from Last.fm, enriched with Spotify IDs)

--- a/docs/2026-03-20-user-artist-playcount-design.md
+++ b/docs/2026-03-20-user-artist-playcount-design.md
@@ -1,0 +1,30 @@
+# User Artist Playcount — Design
+
+**Issue:** [#25](https://github.com/rianvdm/listentomore/issues/25)
+**Date:** 2026-03-20
+
+## Goal
+
+Show the logged-in user's personal playcount for an artist on the artist detail page. Logged-out users see no change.
+
+## Approach
+
+Piggyback on the existing `/api/internal/artist-lastfm` call. Last.fm's `artist.getInfo` accepts an optional `username` parameter and returns `userplaycount` when provided.
+
+## Changes
+
+1. **`packages/services/lastfm/src/artist-details.ts`** — Add optional `username` param to the `artist.getInfo` API call. Include `userplaycount` in the returned data.
+
+2. **`apps/web/src/api/internal/artist.ts`** — Accept `username` query param on the artist-lastfm endpoint. Pass it through to the service.
+
+3. **`apps/web/src/pages/artist/detail.tsx`** — When `currentUser` exists, pass their Last.fm username in the fetch URL. Render playcount in the metadata area alongside genres.
+
+## Display
+
+* Shown in the metadata section alongside genres (e.g., "42 plays", "0 plays")
+* Only rendered when a user is logged in
+* Styled consistently with existing metadata elements
+
+## Caching
+
+Cache key must include username when provided, so one user's playcount isn't served to another.

--- a/docs/2026-03-20-user-artist-playcount-plan.md
+++ b/docs/2026-03-20-user-artist-playcount-plan.md
@@ -1,0 +1,204 @@
+# User Artist Playcount Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the logged-in user's personal Last.fm playcount on the artist detail page.
+
+**Architecture:** Pass the logged-in user's Last.fm username through the existing `/api/internal/artist-lastfm` endpoint to the `artist.getInfo` API call. Last.fm returns `userplaycount` when `username` is provided. Render it in the metadata section alongside genres.
+
+**Tech Stack:** Hono, TypeScript, Last.fm API, Cloudflare Workers
+
+---
+
+### Task 1: Add username param to Last.fm artist detail service
+
+**Files:**
+- Modify: `packages/services/lastfm/src/artist-detail.ts`
+- Modify: `packages/services/lastfm/src/index.ts`
+
+- [ ] **Step 1: Add `userplaycount` to the `ArtistDetail` interface**
+
+In `packages/services/lastfm/src/artist-detail.ts`, add optional field:
+
+```typescript
+export interface ArtistDetail {
+  name: string;
+  url: string;
+  image: string | null;
+  tags: string[];
+  similar: string[];
+  bio: string;
+  userplaycount?: number;  // <-- add this
+}
+```
+
+- [ ] **Step 2: Add optional `username` param to `getArtistDetail`**
+
+Change the method signature and URL construction:
+
+```typescript
+async getArtistDetail(artistName: string, username?: string): Promise<ArtistDetail> {
+```
+
+Append username to the API URL when provided:
+
+```typescript
+let url = `${LASTFM_API_BASE}/?method=artist.getInfo&artist=${encodeURIComponent(artistName)}&api_key=${encodeURIComponent(this.config.apiKey)}&format=json&autocorrect=1`;
+if (username) {
+  url += `&username=${encodeURIComponent(username)}`;
+}
+```
+
+- [ ] **Step 3: Include username in cache key when provided**
+
+The shared artist data should stay cached normally. When username is provided, use a separate cache key:
+
+```typescript
+const cacheKey = username
+  ? `lastfm:artistDetail:${artistName.toLowerCase().trim()}:user:${username.toLowerCase()}`
+  : `lastfm:artistDetail:${artistName.toLowerCase().trim()}`;
+```
+
+- [ ] **Step 4: Extract userplaycount from response**
+
+In the result construction, add:
+
+```typescript
+const userplaycount = username && artist.stats?.userplaycount
+  ? parseInt(artist.stats.userplaycount, 10)
+  : undefined;
+
+const result: ArtistDetail = {
+  name: artist.name,
+  url: artist.url,
+  image: artist.image?.find((img) => img.size === 'extralarge')?.['#text'] || null,
+  tags: filteredTags,
+  similar: artist.similar?.artist?.slice(0, 3).map((a) => a.name) || [],
+  bio: artist.bio?.content || '',
+  ...(userplaycount !== undefined && { userplaycount }),
+};
+```
+
+- [ ] **Step 5: Update convenience method in LastfmService**
+
+In `packages/services/lastfm/src/index.ts`, update:
+
+```typescript
+async getArtistDetail(artistName: string, username?: string) {
+  return this.artistDetails.getArtistDetail(artistName, username);
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/services/lastfm/src/artist-detail.ts packages/services/lastfm/src/index.ts
+git commit -m "feat: add username param to artist detail for user playcount (#25)"
+```
+
+---
+
+### Task 2: Pass username through the API route
+
+**Files:**
+- Modify: `apps/web/src/api/internal/artist.ts`
+
+- [ ] **Step 1: Accept and pass username query param**
+
+In the `/artist-lastfm` handler, read the username param and pass it through:
+
+```typescript
+app.get('/artist-lastfm', async (c) => {
+  const name = c.req.query('name');
+  const username = c.req.query('username');
+
+  if (!name) {
+    return c.json({ error: 'Missing name parameter' }, 400);
+  }
+
+  try {
+    const lastfm = c.get('lastfm');
+    const [artistDetail, topAlbums] = await Promise.all([
+      lastfm.getArtistDetail(name, username || undefined),
+      lastfm.getArtistTopAlbums(name, 3),
+    ]);
+    return c.json({
+      data: {
+        ...artistDetail,
+        topAlbums: topAlbums.map((a) => a.name),
+      },
+    });
+  } catch (error) {
+    console.error('Internal lastfm artist error:', error);
+    return c.json({ error: 'Failed to fetch Last.fm data' }, 500);
+  }
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/api/internal/artist.ts
+git commit -m "feat: pass username to artist-lastfm endpoint (#25)"
+```
+
+---
+
+### Task 3: Render playcount on the artist page
+
+**Files:**
+- Modify: `apps/web/src/pages/artist/detail.tsx`
+
+- [ ] **Step 1: Pass username in the fetch URL**
+
+In the progressive loading script, inject the current user's Last.fm username and append it to the fetch URL. After the `artistId` variable declaration (~line 109), add:
+
+```javascript
+var lastfmUsername = ${currentUser?.lastfm_username ? JSON.stringify(currentUser.lastfm_username) : 'null'};
+```
+
+Update the fetch URL:
+
+```javascript
+var lastfmUrl = '/api/internal/artist-lastfm?name=' + encodeURIComponent(artistName);
+if (lastfmUsername) {
+  lastfmUrl += '&username=' + encodeURIComponent(lastfmUsername);
+}
+internalFetch(lastfmUrl, { cache: 'no-store' })
+```
+
+- [ ] **Step 2: Add a playcount placeholder in the HTML**
+
+After the genre-section paragraph (~line 78), add:
+
+```tsx
+{/* User playcount - populated via JS for logged-in users */}
+<p id="user-playcount" style={{ display: 'none' }}></p>
+```
+
+- [ ] **Step 3: Render the playcount in the JS callback**
+
+In the `.then(function(data) { ... })` callback for the Last.fm fetch, after updating genres, add:
+
+```javascript
+// Show user playcount if available
+if (lastfmUsername && lastfm.userplaycount !== undefined) {
+  var count = lastfm.userplaycount;
+  var el = document.getElementById('user-playcount');
+  el.innerHTML = '<strong>Your plays:</strong> ' + count.toLocaleString();
+  el.style.display = '';
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+cd apps/web && pnpm build
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/artist/detail.tsx
+git commit -m "feat: show user playcount on artist page for logged-in users (#25)"
+```

--- a/packages/services/lastfm/src/artist-detail.ts
+++ b/packages/services/lastfm/src/artist-detail.ts
@@ -13,6 +13,7 @@ export interface ArtistDetail {
   tags: string[];
   similar: string[];
   bio: string;
+  userplaycount?: number;
 }
 
 export interface ArtistTopAlbum {
@@ -66,9 +67,11 @@ export class ArtistDetails {
     private cache?: KVNamespace
   ) {}
 
-  async getArtistDetail(artistName: string): Promise<ArtistDetail> {
-    // Normalize artist name for cache key
-    const cacheKey = `lastfm:artistDetail:${artistName.toLowerCase().trim()}`;
+  async getArtistDetail(artistName: string, username?: string): Promise<ArtistDetail> {
+    // Normalize artist name for cache key (include username when provided)
+    const cacheKey = username
+      ? `lastfm:artistDetail:${artistName.toLowerCase().trim()}:user:${username.toLowerCase()}`
+      : `lastfm:artistDetail:${artistName.toLowerCase().trim()}`;
 
     // Check cache first
     if (this.cache) {
@@ -78,7 +81,10 @@ export class ArtistDetails {
       }
     }
 
-    const url = `${LASTFM_API_BASE}/?method=artist.getInfo&artist=${encodeURIComponent(artistName)}&api_key=${encodeURIComponent(this.config.apiKey)}&format=json&autocorrect=1`;
+    let url = `${LASTFM_API_BASE}/?method=artist.getInfo&artist=${encodeURIComponent(artistName)}&api_key=${encodeURIComponent(this.config.apiKey)}&format=json&autocorrect=1`;
+    if (username) {
+      url += `&username=${encodeURIComponent(username)}`;
+    }
 
     const response = await fetchWithTimeout(url, { timeout: 'fast' });
     const data = (await response.json()) as LastfmArtistInfoResponse;
@@ -97,6 +103,10 @@ export class ArtistDetails {
           .map((tag) => tag.name.charAt(0).toUpperCase() + tag.name.slice(1))
       : [];
 
+    const userplaycount = username && artist.stats?.userplaycount
+      ? parseInt(artist.stats.userplaycount, 10)
+      : undefined;
+
     const result: ArtistDetail = {
       name: artist.name,
       url: artist.url,
@@ -104,6 +114,7 @@ export class ArtistDetails {
       tags: filteredTags,
       similar: artist.similar?.artist?.slice(0, 3).map((a) => a.name) || [],
       bio: artist.bio?.content || '',
+      ...(userplaycount !== undefined && { userplaycount }),
     };
 
     // Cache result

--- a/packages/services/lastfm/src/index.ts
+++ b/packages/services/lastfm/src/index.ts
@@ -66,8 +66,8 @@ export class LastfmService {
     return this.topArtists.getTopArtists(period, limit);
   }
 
-  async getArtistDetail(artistName: string) {
-    return this.artistDetails.getArtistDetail(artistName);
+  async getArtistDetail(artistName: string, username?: string) {
+    return this.artistDetails.getArtistDetail(artistName, username);
   }
 
   async getArtistTopAlbums(artistName: string, limit: number = 5) {


### PR DESCRIPTION
## Summary

* When a logged-in user visits an artist page, their personal Last.fm playcount for that artist is now shown in the metadata section alongside genres
* Piggybacks on the existing `artist.getInfo` API call by passing the user's Last.fm username
* Logged-out users see no change

Closes #25

## Test plan

* [x] Verified on live site — playcount renders correctly for logged-in users
* [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)