### PR TITLE
Migrate Spotify auth to Client Credentials flow

### DIFF
--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -30,7 +30,6 @@ interface Env {
   // Service credentials
   SPOTIFY_CLIENT_ID: string;
   SPOTIFY_CLIENT_SECRET: string;
-  SPOTIFY_REFRESH_TOKEN: string;
   LASTFM_API_KEY: string;
   OPENAI_API_KEY: string;
   // Apple MusicKit credentials (for streaming links)
@@ -55,7 +54,6 @@ function createServices(env: Env): Services {
     spotify: new SpotifyService({
       clientId: env.SPOTIFY_CLIENT_ID,
       clientSecret: env.SPOTIFY_CLIENT_SECRET,
-      refreshToken: env.SPOTIFY_REFRESH_TOKEN,
       cache: env.CACHE,
     }),
     // Last.fm service factory - needs username per request

--- a/apps/discord-bot/wrangler.toml
+++ b/apps/discord-bot/wrangler.toml
@@ -30,7 +30,6 @@ ENVIRONMENT = "production"
 # Services:
 # - SPOTIFY_CLIENT_ID
 # - SPOTIFY_CLIENT_SECRET
-# - SPOTIFY_REFRESH_TOKEN
 # - LASTFM_API_KEY
 # - OPENAI_API_KEY
 # Apple MusicKit (for streaming links):

--- a/apps/web/src/__tests__/services/spotify-auth.test.ts
+++ b/apps/web/src/__tests__/services/spotify-auth.test.ts
@@ -1,0 +1,52 @@
+// Client Credentials token-request tests for SpotifyAuth
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SpotifyAuth } from '@listentomore/spotify';
+import { createMockKV, setupFetchMock } from '../utils/mocks';
+
+describe('SpotifyAuth (Client Credentials)', () => {
+  let mockKV: KVNamespace;
+
+  beforeEach(() => {
+    mockKV = createMockKV();
+  });
+
+  it('requests a token via the client_credentials grant with no refresh_token', async () => {
+    const mockFetch = setupFetchMock([
+      {
+        pattern: 'accounts.spotify.com/api/token',
+        response: { access_token: 'cc-token', expires_in: 3600 },
+      },
+    ]);
+
+    const auth = new SpotifyAuth({ clientId: 'abc12345', clientSecret: 'shh' }, mockKV);
+    const token = await auth.getAccessToken();
+
+    expect(token).toBe('cc-token');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain('accounts.spotify.com/api/token');
+
+    const body = (init as RequestInit).body as string;
+    expect(body).toContain('grant_type=client_credentials');
+    expect(body).not.toContain('refresh_token');
+
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Basic ${btoa('abc12345:shh')}`);
+  });
+
+  it('caches the token and skips the fetch on the next call', async () => {
+    const mockFetch = setupFetchMock([
+      {
+        pattern: 'accounts.spotify.com/api/token',
+        response: { access_token: 'cc-token', expires_in: 3600 },
+      },
+    ]);
+
+    const auth = new SpotifyAuth({ clientId: 'abc12345', clientSecret: 'shh' }, mockKV);
+    await auth.getAccessToken();
+    await auth.getAccessToken();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1); // second call served from KV cache
+  });
+});

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -87,7 +87,6 @@ app.use('*', async (c, next) => {
   const spotify = new SpotifyService({
     clientId: c.env.SPOTIFY_CLIENT_ID,
     clientSecret: c.env.SPOTIFY_CLIENT_SECRET,
-    refreshToken: c.env.SPOTIFY_REFRESH_TOKEN,
     cache: c.env.CACHE,
   });
   c.set('spotify', spotify);
@@ -98,7 +97,6 @@ app.use('*', async (c, next) => {
     ? new SpotifyService({
       clientId: c.env.SPOTIFY_STREAMING_CLIENT_ID!,
       clientSecret: c.env.SPOTIFY_STREAMING_CLIENT_SECRET!,
-      refreshToken: c.env.SPOTIFY_STREAMING_REFRESH_TOKEN!,
       cache: c.env.CACHE,
     })
     : spotify;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -16,11 +16,9 @@ export type Bindings = {
   // Environment variables
   SPOTIFY_CLIENT_ID: string;
   SPOTIFY_CLIENT_SECRET: string;
-  SPOTIFY_REFRESH_TOKEN: string;
   // Secondary Spotify app for streaming-links (rate limit isolation)
   SPOTIFY_STREAMING_CLIENT_ID?: string;
   SPOTIFY_STREAMING_CLIENT_SECRET?: string;
-  SPOTIFY_STREAMING_REFRESH_TOKEN?: string;
   LASTFM_API_KEY: string;
   LASTFM_SHARED_SECRET?: string;
   LASTFM_USERNAME: string;

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -49,10 +49,8 @@ crons = ["*/5 * * * *"]  # Run every 5 minutes (random fact only at top of hour)
 # Note: Secrets should be set with `wrangler secret put`:
 # - SPOTIFY_CLIENT_ID
 # - SPOTIFY_CLIENT_SECRET
-# - SPOTIFY_REFRESH_TOKEN
 # - SPOTIFY_STREAMING_CLIENT_ID (secondary app for streaming-links rate limit isolation)
 # - SPOTIFY_STREAMING_CLIENT_SECRET
-# - SPOTIFY_STREAMING_REFRESH_TOKEN
 # - LASTFM_API_KEY
 # - OPENAI_API_KEY
 # - DISCOGS_API_TOKEN

--- a/docs/superpowers/plans/2026-06-21-spotify-client-credentials.md
+++ b/docs/superpowers/plans/2026-06-21-spotify-client-credentials.md
@@ -1,0 +1,299 @@
+# Spotify Client Credentials Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move both Spotify apps off Authorization Code refresh tokens to the Client Credentials flow, so the 6-month refresh-token expiry (existing apps from 2026-07-20) can never break catalog access.
+
+**Architecture:** `SpotifyAuth` (`packages/services/spotify/src/auth.ts`) requests an app token with `grant_type=client_credentials` and Basic `clientId:clientSecret` auth, caching it in KV by client ID. The `refreshToken` field is removed from the config and threaded out of all three construction sites. The two-app rate-limit split (primary + streaming) is preserved — each just uses its own client ID/secret. No user-scoped endpoints are involved.
+
+**Tech Stack:** TypeScript, Cloudflare Workers, Hono, vitest, pnpm 9.14.2 + turbo, Node 22.
+
+## Global Constraints
+
+- Client Credentials is for catalog endpoints only; no user scopes, no `/me`. (Verified: only `/search`, `/artists/{id}`, `/artists/{id}/albums`, `/artists/{id}/related-artists`, `/albums/{id}` are used.)
+- No new Spotify app/dashboard registration — a registered app supports Client Credentials with its existing client ID/secret. Only the grant type changes.
+- Keep the two-app rate-limit split (primary + streaming). Do not consolidate.
+- `packages/services/spotify` has **no test runner** (only `typecheck`). All Spotify tests live in the **web** package (`apps/web/src/__tests__/`).
+- Rollout is strict: deploy + verify on Client Credentials BEFORE deleting any refresh-token secret. Never delete first.
+- Spec: `docs/superpowers/specs/2026-06-21-spotify-client-credentials-design.md`.
+
+---
+
+### Task 1: Swap the token request to Client Credentials (code)
+
+This is one atomic change: TypeScript couples the `SpotifyAuthConfig` change to every caller, so the request swap, the config-field removal, and all call-site updates land together and the build is green at the end. TDD drives the behavior; the plumbing keeps typecheck green.
+
+**Files:**
+- Create: `apps/web/src/__tests__/services/spotify-auth.test.ts`
+- Modify: `packages/services/spotify/src/auth.ts` (interface `:14`, `getAccessToken` `:40`, `refreshAccessToken` `:43-53`, log line `:45`)
+- Modify: `packages/services/spotify/src/index.ts` (config type `:43`, construction `:55`)
+- Modify: `apps/web/src/index.tsx` (`:90`, `:101`)
+- Modify: `apps/web/src/types.ts` (`:19`, `:23`)
+- Modify: `apps/discord-bot/src/index.ts` (`Env` `:33`, construction `:58`)
+- Modify: `apps/web/wrangler.toml` (secret comments `:52`, `:55`)
+- Modify: `apps/discord-bot/wrangler.toml` (secret comment `:33`)
+- Local only (gitignored, not committed): `apps/web/.dev.vars`, `apps/discord-bot/.dev.vars`
+
+**Interfaces:**
+- Consumes: `SpotifyAuth` (exported from `@listentomore/spotify`), `createMockKV` + `setupFetchMock` (from `apps/web/src/__tests__/utils/mocks.ts`).
+- Produces: `SpotifyAuthConfig = { clientId: string; clientSecret: string }` (no `refreshToken`). `SpotifyService` constructor config drops `refreshToken`. `getAccessToken(): Promise<string>` is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/__tests__/services/spotify-auth.test.ts`:
+
+```typescript
+// Client Credentials token-request tests for SpotifyAuth
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SpotifyAuth } from '@listentomore/spotify';
+import { createMockKV, setupFetchMock } from '../utils/mocks';
+
+describe('SpotifyAuth (Client Credentials)', () => {
+  let mockKV: KVNamespace;
+
+  beforeEach(() => {
+    mockKV = createMockKV();
+  });
+
+  it('requests a token via the client_credentials grant with no refresh_token', async () => {
+    const mockFetch = setupFetchMock([
+      {
+        pattern: 'accounts.spotify.com/api/token',
+        response: { access_token: 'cc-token', expires_in: 3600 },
+      },
+    ]);
+
+    const auth = new SpotifyAuth({ clientId: 'abc12345', clientSecret: 'shh' }, mockKV);
+    const token = await auth.getAccessToken();
+
+    expect(token).toBe('cc-token');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain('accounts.spotify.com/api/token');
+
+    const body = (init as RequestInit).body as string;
+    expect(body).toContain('grant_type=client_credentials');
+    expect(body).not.toContain('refresh_token');
+
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Basic ${btoa('abc12345:shh')}`);
+  });
+
+  it('caches the token and skips the fetch on the next call', async () => {
+    const mockFetch = setupFetchMock([
+      {
+        pattern: 'accounts.spotify.com/api/token',
+        response: { access_token: 'cc-token', expires_in: 3600 },
+      },
+    ]);
+
+    const auth = new SpotifyAuth({ clientId: 'abc12345', clientSecret: 'shh' }, mockKV);
+    await auth.getAccessToken();
+    await auth.getAccessToken();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1); // second call served from KV cache
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd apps/web && npx vitest run src/__tests__/services/spotify-auth.test.ts`
+Expected: FAIL on the first test — the current code sends `grant_type=refresh_token` (with `refresh_token=undefined` because the test passes no refresh token), so `body` does not contain `grant_type=client_credentials`.
+
+- [ ] **Step 3: Change the token request in `auth.ts`**
+
+In `packages/services/spotify/src/auth.ts`:
+
+Remove `refreshToken` from the config interface (`:14-18`):
+
+```typescript
+export interface SpotifyAuthConfig {
+  clientId: string;
+  clientSecret: string;
+}
+```
+
+Rename the call in `getAccessToken` (`:40`):
+
+```typescript
+    // Token expired or not in cache - fetch a new one
+    return this.fetchAccessToken();
+```
+
+Rename the method and swap the grant type (`:43-53`). Replace the method signature, log line, and body:
+
+```typescript
+  private async fetchAccessToken(): Promise<string> {
+    const clientIdPrefix = this.config.clientId.substring(0, 8);
+    console.log(`[Spotify] Fetching client-credentials token for app ${clientIdPrefix}...`);
+
+    const credentials = btoa(`${this.config.clientId}:${this.config.clientSecret}`);
+
+    const body = new URLSearchParams({
+      grant_type: 'client_credentials',
+    });
+```
+
+Everything below (the `fetchWithTimeout` POST, the `!response.ok` throw, the `expires_in` math, the KV `put`) stays exactly as is.
+
+- [ ] **Step 4: Thread `refreshToken` out of the callers**
+
+In `packages/services/spotify/src/index.ts` — drop it from the `SpotifyService` config type (`:40-45`) and the `SpotifyAuth` construction (`:51-58`):
+
+```typescript
+  constructor(config: {
+    clientId: string;
+    clientSecret: string;
+    cache: KVNamespace;
+  }) {
+```
+
+```typescript
+    this.auth = new SpotifyAuth(
+      {
+        clientId: config.clientId,
+        clientSecret: config.clientSecret,
+      },
+      config.cache
+    );
+```
+
+In `apps/web/src/index.tsx` — remove the `refreshToken` line from both constructions (delete `:90` and `:101`):
+
+```typescript
+  // Primary Spotify service (album/artist pages, search)
+  const spotify = new SpotifyService({
+    clientId: c.env.SPOTIFY_CLIENT_ID,
+    clientSecret: c.env.SPOTIFY_CLIENT_SECRET,
+    cache: c.env.CACHE,
+  });
+```
+
+```typescript
+  const spotifyStreaming = c.env.SPOTIFY_STREAMING_CLIENT_ID
+    ? new SpotifyService({
+      clientId: c.env.SPOTIFY_STREAMING_CLIENT_ID!,
+      clientSecret: c.env.SPOTIFY_STREAMING_CLIENT_SECRET!,
+      cache: c.env.CACHE,
+    })
+    : spotify;
+```
+
+In `apps/web/src/types.ts` — delete both env fields (`:19` and `:23`): `SPOTIFY_REFRESH_TOKEN: string;` and `SPOTIFY_STREAMING_REFRESH_TOKEN?: string;`. Keep `SPOTIFY_STREAMING_CLIENT_ID` / `SPOTIFY_STREAMING_CLIENT_SECRET`.
+
+In `apps/discord-bot/src/index.ts` — delete the `Env` field (`:33`) `SPOTIFY_REFRESH_TOKEN: string;` and the construction line (`:58`):
+
+```typescript
+    spotify: new SpotifyService({
+      clientId: env.SPOTIFY_CLIENT_ID,
+      clientSecret: env.SPOTIFY_CLIENT_SECRET,
+      cache: env.CACHE,
+    }),
+```
+
+- [ ] **Step 5: Run the new test, verify it passes**
+
+Run: `cd apps/web && npx vitest run src/__tests__/services/spotify-auth.test.ts`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Run the full gates, verify green**
+
+Run: `pnpm test` (from repo root — turbo runs every package's vitest)
+Expected: PASS, no regressions.
+
+Run: `pnpm typecheck` (from repo root — turbo runs `tsc --noEmit` in every package, catching all the type ripples from the removed field)
+Expected: PASS in `@listentomore/spotify`, `apps/web`, `apps/discord-bot`, and all others.
+
+- [ ] **Step 7: Update the secret-comment lists and local `.dev.vars`**
+
+In `apps/web/wrangler.toml` delete the two comment lines (`:52`, `:55`): `# - SPOTIFY_REFRESH_TOKEN` and `# - SPOTIFY_STREAMING_REFRESH_TOKEN`. Keep the `SPOTIFY_STREAMING_CLIENT_ID` / `_SECRET` comment lines.
+
+In `apps/discord-bot/wrangler.toml` delete the comment line (`:33`): `# - SPOTIFY_REFRESH_TOKEN`.
+
+In `apps/web/.dev.vars` and `apps/discord-bot/.dev.vars` (gitignored — local edit only, NOT staged) delete the `SPOTIFY_REFRESH_TOKEN=…` line (and `SPOTIFY_STREAMING_REFRESH_TOKEN=…` in the web one). Keep the client ID/secret lines. These are only needed for the optional `wrangler dev` manual check; the vitest suite doesn't read them.
+
+- [ ] **Step 8: Optional local smoke check (`wrangler dev`)**
+
+Run: `cd apps/web && npx wrangler dev`, then load an album page and an artist page and resolve a streaming link in the local UI. Confirm Spotify data renders with no `SPOTIFY_REFRESH_TOKEN` present. (Skip if you trust the unit + typecheck gates; the real verification is prod in Task 2.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/services/spotify/src/auth.ts \
+        packages/services/spotify/src/index.ts \
+        apps/web/src/index.tsx \
+        apps/web/src/types.ts \
+        apps/web/src/__tests__/services/spotify-auth.test.ts \
+        apps/discord-bot/src/index.ts \
+        apps/web/wrangler.toml \
+        apps/discord-bot/wrangler.toml
+git commit -m "Migrate Spotify auth to Client Credentials flow
+
+Removes the Authorization Code refresh-token dependency (subject to
+Spotify's 6-month expiry from 2026-07-20). Catalog-only access works
+under Client Credentials with the existing client ID/secret pairs."
+```
+
+(`.dev.vars` is gitignored and is intentionally not staged.)
+
+---
+
+### Task 2: Deploy, verify, then delete the dead secrets (manual ops — Rian runs this)
+
+Not agent-drivable: requires a production deploy, live smoke tests, and secret deletion against the real Workers. `ci.yml` is test-only, so deploys are manual. Per the project's workflow, Task 1 is locally tested and approved, then pushed + PR'd + merged to `main` **before** this task. **Order is load-bearing: deploy and verify on Client Credentials BEFORE deleting any secret.** While the old secrets still exist, Client Credentials ignores them, so there is no outage window.
+
+- [ ] **Step 1: Deploy both Workers from `main`**
+
+Ensure wrangler targets the correct account for ListenToMore. Then:
+
+```bash
+# from repo root (turbo deploys both apps):
+pnpm deploy
+# — or per app:
+cd apps/web && npx wrangler deploy
+cd apps/discord-bot && npx wrangler deploy
+```
+
+- [ ] **Step 2: Smoke-test production**
+
+- Load an album page and an artist page on listentomore.com — confirm Spotify-sourced data (cover art, tracks, related artists) renders.
+- Resolve a streaming link (paste a Spotify or Apple Music URL into the streaming-links flow) — confirm cross-platform links return.
+- Run one Discord command that hits Spotify (e.g. `/whatis` or `/listento`) — confirm it responds.
+
+If anything fails, roll back (`wrangler rollback` per Worker, or redeploy the prior commit). The refresh tokens are still valid in Spotify until expiry, so a pre-2026-07-20 revert restores the old flow. Do **not** proceed to Step 3 until prod is green.
+
+- [ ] **Step 3: Delete the dead refresh-token secrets**
+
+Only after Step 2 is green:
+
+```bash
+cd apps/web
+npx wrangler secret delete SPOTIFY_REFRESH_TOKEN
+npx wrangler secret delete SPOTIFY_STREAMING_REFRESH_TOKEN
+
+cd ../discord-bot
+npx wrangler secret delete SPOTIFY_REFRESH_TOKEN
+```
+
+- [ ] **Step 4: Confirm still green after secret deletion**
+
+Reload an album page and run a Discord command once more — confirm Spotify still works with the refresh-token secrets gone. Done: the 6-month expiry can no longer affect ListenToMore.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 token request → Task 1 Steps 1–5. ✓
+- §2 drop `refreshToken` plumbing (all 5 code locations + env types) → Task 1 Step 4. ✓
+- §3 error handling (no new path) → unchanged; `!response.ok` throw kept in Step 3. ✓
+- §4 testing (new CC token-request test in web suite) → Task 1 Steps 1, 5, 6. ✓
+- §5 rollout (deploy → verify → delete secrets, strict order) → Task 2. ✓
+- §6 out of scope (related-artists, future user OAuth, vestigial scopes) → not touched. ✓
+- Files-touched table → all covered across Task 1 (code + wrangler comments + .dev.vars) and Task 2 (secret deletion). ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows the actual code; every command shows expected output. ✓
+
+**Type consistency:** `SpotifyAuthConfig` becomes `{ clientId, clientSecret }` in Task 1 Step 3 and is constructed with exactly those fields in Step 4 (`index.ts`). `SpotifyService` config drops `refreshToken` in Step 4 and is constructed without it at all three call sites in the same step. `getAccessToken()` / `fetchAccessToken()` rename is internal to `auth.ts` (Step 3) and consistent. ✓

--- a/docs/superpowers/specs/2026-06-21-spotify-client-credentials-design.md
+++ b/docs/superpowers/specs/2026-06-21-spotify-client-credentials-design.md
@@ -1,0 +1,103 @@
+# Spotify auth: migrate to Client Credentials flow
+
+**Date:** 2026-06-21
+**Status:** Design approved, ready for plan
+**Branch:** `feat/spotify-client-credentials`
+
+## Problem
+
+Spotify is putting a hard **6-month expiration on refresh tokens** ([announcement, 2026-06-18](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration)). The clock starts at the original authorization and does **not** reset on refresh. On expiry the token endpoint returns `{"error": "invalid_grant"}`.
+
+- New apps: enforced immediately.
+- Existing apps: enforced from **2026-07-20**.
+
+ListenToMore authenticates Spotify with static, app-level **refresh tokens** obtained via the Authorization Code flow — exactly the affected flow. After the 6-month mark these tokens expire and every Spotify-backed feature (album/artist pages, search, streaming links, the Discord bot's lookups) breaks. Because this is the developer's own authorization rather than per-user OAuth, there is no end user to "re-login" — under the current design the only recovery is a manual re-authorization and secret rotation every six months.
+
+## Verification (why Client Credentials is the right fix)
+
+1. **LTM is on the affected flow.** `packages/services/spotify/src/auth.ts:43` posts `grant_type=refresh_token` with static secrets `SPOTIFY_REFRESH_TOKEN` and `SPOTIFY_STREAMING_REFRESH_TOKEN`. The announcement: *"This only applies to tokens issued on behalf of a user (Authorization Code and Authorization Code with PKCE flows)."*
+2. **Every Spotify call is catalog-only.** The only endpoints used are `/search`, `/artists/{id}`, `/artists/{id}/albums`, `/artists/{id}/related-artists`, `/albums/{id}` (in `search.ts`, `artists.ts`, `albums.ts`). `streaming-links` calls no Spotify API directly — it consumes the injected `SpotifyService`. No `/me`, no user scopes.
+3. **Nothing forces Authorization Code.** The classic reason to use a user token for catalog data — `market=from_token` — is not used. The only market reference is a hardcoded `market: 'US'` (`artists.ts:141`), which is what Client Credentials needs anyway.
+4. **Client Credentials is exempt and needs no refresh token.** Spotify's [Client Credentials tutorial](https://developer.spotify.com/documentation/web-api/tutorials/client-credentials-flow) returns only `access_token`, `token_type`, `expires_in` — no refresh token. The announcement FAQ: *"Does this affect Client Credentials flow? No."*
+
+Migrating to Client Credentials doesn't just handle the expiry; it removes the refresh-token lifecycle entirely. There is nothing to re-authorize, ever.
+
+## Decision
+
+**Approach A — surgical Client Credentials swap.** Move both Spotify apps to `grant_type=client_credentials`, remove the two refresh-token secrets and the `refreshToken` config field, add a direct unit test for the new token request, and keep everything else (including the two-app rate-limit split) as is.
+
+Rejected alternatives:
+- **Consolidate to one app** — would also merge the secondary "streaming" Spotify app into the primary, but loses the rate-limit isolation that app exists to provide. No reason to change architecture during an auth migration.
+- **Stay on Authorization Code, harden** — detect `invalid_grant`, alert, document a manual ~6-month re-auth runbook. Smallest diff today but keeps the time bomb and adds recurring toil. Strictly worse for a catalog-only consumer.
+
+## Design
+
+### 1. Token request — `packages/services/spotify/src/auth.ts`
+
+The only behavioral change.
+
+- Rename `refreshAccessToken()` → `fetchAccessToken()` (it no longer refreshes anything).
+- Swap the POST body from `{ grant_type: 'refresh_token', refresh_token }` to `{ grant_type: 'client_credentials' }`.
+- Remove `refreshToken` from the `SpotifyAuthConfig` interface (`auth.ts:14`).
+- Unchanged: the `https://accounts.spotify.com/api/token` URL, the Basic `clientId:clientSecret` auth header, the KV token cache keyed by client ID, the `expires_in` math with the 60-second early-expiry buffer, and `fetchWithTimeout('fast')`. The response is already parsed as `{ access_token, expires_in }`, which is exactly the Client Credentials response shape.
+- `getAccessToken()` is untouched. The class's public surface is identical, so `search.ts` / `albums.ts` / `artists.ts` need no changes.
+
+No new Spotify app or dashboard change is required — a registered app supports Client Credentials with its existing client ID / secret. Only the grant type changes.
+
+### 2. Drop `refreshToken` through the wiring
+
+- `packages/services/spotify/src/index.ts` — `SpotifyService` config type (`:43`) and the `SpotifyAuth` construction (`:55`).
+- `apps/web/src/index.tsx` — both constructions (`:90` primary, `:101` secondary). The secondary-app fallback stays gated on `SPOTIFY_STREAMING_CLIENT_ID` (`:97`).
+- `apps/discord-bot/src/index.ts` — the construction (`:58`) and the `Env` field (`:33`).
+- `apps/web/src/types.ts` — `SPOTIFY_REFRESH_TOKEN` (`:19`) and `SPOTIFY_STREAMING_REFRESH_TOKEN` (`:23`).
+- `.dev.vars` (both apps) and the `wrangler.toml` secret-comment lists. Keep both client ID / secret pairs.
+
+### 3. Error handling
+
+No new path. Client Credentials has no `invalid_grant` / refresh-token lifecycle; a 4xx now means bad client credentials, which is a deploy-time config error. The existing `if (!response.ok) throw` (`auth.ts:65`) already surfaces it.
+
+### 4. Testing
+
+`packages/services/spotify` has no test runner (only `typecheck`), so Spotify logic is tested from the web package. Add one focused test under `apps/web/src/__tests__/services/` that constructs a real `SpotifyAuth` (exported from the `@listentomore/spotify` barrel) with `setupFetchMock` + `createMockKV`, asserting:
+
+1. the token POST body is `grant_type=client_credentials` with the Basic header and **no** `refresh_token`;
+2. the returned token is cached;
+3. a cache hit skips the fetch.
+
+Existing tests are unaffected — they mock at the `getAccessToken()` boundary (`createMockSpotifyAuth`, `mocks.ts:80`), which is also why no current test exercises the request body. Gate: full web suite green + `typecheck`.
+
+### 5. Rollout (load-bearing — this is production auth)
+
+Strict ordering so there is no outage window:
+
+1. Land and deploy the code. While the old secrets still exist, Client Credentials ignores them — nothing breaks.
+2. Verify locally: `.dev.vars` with Client Credentials creds, then exercise an album page, an artist page, and a streaming-link resolution; run the full suite.
+3. Deploy web + discord-bot. Smoke-test prod: an album/artist render, a streaming link, and one Discord command.
+4. **Only after prod is verified green**, delete the dead secrets: `wrangler secret delete SPOTIFY_REFRESH_TOKEN` (+ `SPOTIFY_STREAMING_REFRESH_TOKEN` on web).
+
+Rollback is a plain deploy-revert; the refresh tokens stay valid in Spotify until their 6-month expiry, so a revert before 2026-07-20 still works. Cached `spotify:token:<clientId>` entries are plain bearer tokens (same shape under Client Credentials), so no cache migration is needed.
+
+## Out of scope (flagged, not touched)
+
+- The `/artists/{id}/related-artists` Nov-2024 deprecation for Development-Mode apps — pre-existing and orthogonal to the OAuth flow.
+- Any future "log in with Spotify" user feature — that would need a separate user-OAuth path and would itself be subject to the 6-month expiry, handled per-user via re-login. Build only if and when needed.
+- The vestigial `user-read-private` / `user-read-email` scopes from the original authorization — irrelevant under Client Credentials, nothing in code to remove.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `packages/services/spotify/src/auth.ts` | grant type → `client_credentials`; rename method; drop `refreshToken` from `SpotifyAuthConfig` |
+| `packages/services/spotify/src/index.ts` | drop `refreshToken` from `SpotifyService` config + `SpotifyAuth` construction |
+| `apps/web/src/index.tsx` | drop `refreshToken` from both constructions |
+| `apps/web/src/types.ts` | remove `SPOTIFY_REFRESH_TOKEN` + `SPOTIFY_STREAMING_REFRESH_TOKEN` |
+| `apps/discord-bot/src/index.ts` | drop `refreshToken` from construction + `Env` field |
+| `apps/web/src/__tests__/services/*` | new Client Credentials token-request test |
+| `apps/web/.dev.vars`, `apps/discord-bot/.dev.vars` | remove refresh-token lines |
+| `apps/web/wrangler.toml`, `apps/discord-bot/wrangler.toml` | remove refresh-token comment lines |
+| Spotify dashboard / `wrangler secret delete` | remove `SPOTIFY_REFRESH_TOKEN` (both Workers) + `SPOTIFY_STREAMING_REFRESH_TOKEN` (web), post-verify |
+
+## References
+
+- [Spotify: Refresh token expiration (2026-06-18)](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration)
+- [Spotify: Client Credentials flow tutorial](https://developer.spotify.com/documentation/web-api/tutorials/client-credentials-flow)

--- a/packages/services/spotify/src/auth.ts
+++ b/packages/services/spotify/src/auth.ts
@@ -14,7 +14,6 @@ export interface SpotifyTokenData {
 export interface SpotifyAuthConfig {
   clientId: string;
   clientSecret: string;
-  refreshToken: string;
 }
 
 export class SpotifyAuth {
@@ -36,20 +35,18 @@ export class SpotifyAuth {
       return cached.access_token;
     }
 
-    // Token expired or not in cache - refresh it
-    return this.refreshAccessToken();
+    // Token expired or not in cache - fetch a new one
+    return this.fetchAccessToken();
   }
 
-  private async refreshAccessToken(): Promise<string> {
+  private async fetchAccessToken(): Promise<string> {
     const clientIdPrefix = this.config.clientId.substring(0, 8);
-    console.log(`[Spotify] Refreshing token for app ${clientIdPrefix}...`);
+    console.log(`[Spotify] Fetching client-credentials token for app ${clientIdPrefix}...`);
 
     const credentials = btoa(`${this.config.clientId}:${this.config.clientSecret}`);
 
-    // URL-encode the refresh token to handle special characters
     const body = new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: this.config.refreshToken,
+      grant_type: 'client_credentials',
     });
 
     const response = await fetchWithTimeout(SPOTIFY_TOKEN_URL, {

--- a/packages/services/spotify/src/index.ts
+++ b/packages/services/spotify/src/index.ts
@@ -40,7 +40,6 @@ export class SpotifyService {
   constructor(config: {
     clientId: string;
     clientSecret: string;
-    refreshToken: string;
     cache: KVNamespace;
   }) {
     this.clientIdPrefix = config.clientId.substring(0, 8);
@@ -52,7 +51,6 @@ export class SpotifyService {
       {
         clientId: config.clientId,
         clientSecret: config.clientSecret,
-        refreshToken: config.refreshToken,
       },
       config.cache
     );


### PR DESCRIPTION
## Why

Spotify is enforcing a **6-month expiry on refresh tokens** (existing apps from 2026-07-20, [announcement](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration)). ListenToMore authenticated Spotify with static **Authorization Code refresh tokens** for catalog-only data — exactly the affected flow. The **Client Credentials** flow needs no refresh token and is explicitly exempt, so this removes the expiry problem permanently rather than just handling it.

## What

- `auth.ts`: request app tokens via `grant_type=client_credentials` (rename `refreshAccessToken` → `fetchAccessToken`); drop `refreshToken` from `SpotifyAuthConfig`. Cache/`expires_in`/Basic-auth logic unchanged.
- Thread `refreshToken` out of `SpotifyService` + all three call sites (web ×2, discord ×1) + both env type defs + both `wrangler.toml` secret-comment lists.
- New unit test asserting the CC token request (`grant_type=client_credentials`, Basic header, no `refresh_token`, caching).
- Keeps the two-app rate-limit split. No new Spotify app registration — the existing client ID/secret pairs work for Client Credentials.

Every Spotify endpoint used is catalog-only (`/search`, `/albums/{id}`, `/artists/{id}`, `/artists/{id}/albums`, `/artists/{id}/related-artists`) — no user scopes, no `market=from_token` — so Client Credentials covers 100%.

## Verification

- TDD red→green; `tsc --noEmit` clean (spotify/web/discord); web suite **77 passed**, discord **16 passed**.
- Direct against Spotify with a CC token from the prod creds: token endpoint **200**, `/search` **200 (5 items)**, `/albums/{id}` + `/artists/{id}` **200** with real data.
- Local browser smoke (album / artist / search) confirmed.

Design spec: `docs/superpowers/specs/2026-06-21-spotify-client-credentials-design.md`
Plan: `docs/superpowers/plans/2026-06-21-spotify-client-credentials.md`

## Post-merge ops

- [ ] Deploy `apps/web` + `apps/discord-bot`
- [ ] After prod verify, delete dead secrets: `SPOTIFY_REFRESH_TOKEN` (both Workers) + `SPOTIFY_STREAMING_REFRESH_TOKEN` (web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
