### PR TITLE
Warmer /insights voice (few-shot) + Claude Sonnet 5 (#32)

### DIFF
--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -32,6 +32,7 @@ interface Env {
   SPOTIFY_CLIENT_SECRET: string;
   LASTFM_API_KEY: string;
   OPENAI_API_KEY: string;
+  ANTHROPIC_API_KEY: string;
   // Apple MusicKit credentials (for streaming links)
   APPLE_KEY_ID: string;
   APPLE_TEAM_ID: string;
@@ -72,6 +73,7 @@ function createServices(env: Env): Services {
     }),
     ai: new AIService({
       openaiApiKey: env.OPENAI_API_KEY,
+      anthropicApiKey: env.ANTHROPIC_API_KEY,
       cache: env.CACHE,
     }),
   };

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -1,7 +1,7 @@
 // AIService integration tests
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OpenAIClient, AICache, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
+import { OpenAIClient, AICache, AIRateLimiter, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
 import { createMockKV, setupFetchMock } from '../utils/mocks';
 
 describe('OpenAIClient', () => {
@@ -294,5 +294,19 @@ describe('generateArtistSentence', () => {
 
     expect(result).toEqual(cachedResult);
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('AIRateLimiter — provider-aware limits', () => {
+  it('uses the anthropic rate limit, not openai', async () => {
+    const rl = new AIRateLimiter(createMockKV(), 'anthropic');
+    const stats = await rl.getStats();
+    expect(stats.provider).toBe('anthropic');
+    expect(stats.maxRequests).toBe(50);
+  });
+
+  it('still reports the openai limit for the openai provider', async () => {
+    const rl = new AIRateLimiter(createMockKV(), 'openai');
+    expect((await rl.getStats()).maxRequests).toBe(90);
   });
 });

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -1,7 +1,7 @@
 // AIService integration tests
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OpenAIClient, AICache, AIRateLimiter, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
+import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
 import { createMockKV, setupFetchMock } from '../utils/mocks';
 
 describe('OpenAIClient', () => {
@@ -308,5 +308,73 @@ describe('AIRateLimiter — provider-aware limits', () => {
   it('still reports the openai limit for the openai provider', async () => {
     const rl = new AIRateLimiter(createMockKV(), 'openai');
     expect((await rl.getStats()).maxRequests).toBe(90);
+  });
+});
+
+describe('AnthropicClient.chatCompletion', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function lastBody(mockFetch: ReturnType<typeof setupFetchMock>) {
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    return JSON.parse(init.body as string);
+  }
+
+  it('extracts the system message to the top-level system param', async () => {
+    const mockFetch = setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { model: 'claude-sonnet-4-6', content: [{ type: 'text', text: 'hi' }] } },
+    ]);
+    await new AnthropicClient('key').chatCompletion({
+      model: 'claude-sonnet-4-6',
+      messages: [
+        { role: 'system', content: 'You are a friend.' },
+        { role: 'user', content: 'My week...' },
+      ],
+      maxTokens: 1500,
+      temperature: 0.8,
+    });
+    const body = lastBody(mockFetch);
+    expect(body.system).toBe('You are a friend.');
+    expect(body.messages).toEqual([{ role: 'user', content: 'My week...' }]);
+    expect(body.max_tokens).toBe(1500);
+    expect(body.temperature).toBe(0.8);
+  });
+
+  it('omits temperature for opus-tier models', async () => {
+    const mockFetch = setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { model: 'claude-opus-4-8', content: [{ type: 'text', text: 'x' }] } },
+    ]);
+    await new AnthropicClient('key').chatCompletion({
+      model: 'claude-opus-4-8',
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 1500,
+      temperature: 0.8,
+    });
+    expect(lastBody(mockFetch).temperature).toBeUndefined();
+  });
+
+  it('maps the response to content + anthropic metadata', async () => {
+    setupFetchMock([
+      {
+        pattern: /api\.anthropic\.com/,
+        response: { model: 'claude-sonnet-4-6', content: [{ type: 'text', text: 'warm summary' }], usage: { input_tokens: 100, output_tokens: 50 } },
+      },
+    ]);
+    const res = await new AnthropicClient('key').chatCompletion({
+      model: 'claude-sonnet-4-6',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(res.content).toBe('warm summary');
+    expect(res.metadata?.provider).toBe('anthropic');
+    expect(res.metadata?.api).toBe('messages');
+    expect(res.metadata?.usage).toEqual({ inputTokens: 100, outputTokens: 50, totalTokens: 150 });
+  });
+
+  it('throws on a non-200 response', async () => {
+    setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { error: 'bad' }, options: { status: 400, ok: false } },
+    ]);
+    await expect(
+      new AnthropicClient('key').chatCompletion({ model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }] })
+    ).rejects.toThrow('Anthropic API error');
   });
 });

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, AIService, buildUserInsightsMessages, generateUserInsightsSummary, USER_INSIGHTS_PROMPT_VERSION, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
+import { getTaskConfig } from '@listentomore/config';
 import { createMockKV, setupFetchMock } from '../utils/mocks';
 
 describe('OpenAIClient', () => {
@@ -464,5 +465,19 @@ describe('generateUserInsightsSummary cache key', () => {
       expect.any(String),
       expect.any(Object)
     );
+  });
+});
+
+describe('userInsightsSummary provider flip', () => {
+  it('is configured for anthropic sonnet', () => {
+    const cfg = getTaskConfig('userInsightsSummary');
+    expect(cfg.provider).toBe('anthropic');
+    expect(cfg.model).toBe('claude-sonnet-4-6');
+    expect(cfg.temperature).toBe(0.8);
+  });
+
+  it('routes the task to the anthropic client', () => {
+    const ai = new AIService({ openaiApiKey: 'o', anthropicApiKey: 'a', cache: createMockKV() });
+    expect(ai.getClientForTask('userInsightsSummary')).toBe(ai.anthropic);
   });
 });

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -1,7 +1,7 @@
 // AIService integration tests
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
+import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, AIService, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
 import { createMockKV, setupFetchMock } from '../utils/mocks';
 
 describe('OpenAIClient', () => {
@@ -376,5 +376,21 @@ describe('AnthropicClient.chatCompletion', () => {
     await expect(
       new AnthropicClient('key').chatCompletion({ model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }] })
     ).rejects.toThrow('Anthropic API error');
+  });
+});
+
+describe('AIService.getClientForTask', () => {
+  function makeService() {
+    return new AIService({ openaiApiKey: 'o', anthropicApiKey: 'a', cache: createMockKV() });
+  }
+
+  it('returns the OpenAI client for an openai-provider task', () => {
+    const ai = makeService();
+    expect(ai.getClientForTask('artistSummary')).toBe(ai.openai);
+  });
+
+  it('exposes a constructed anthropic client', () => {
+    const ai = makeService();
+    expect(ai.anthropic).toBeInstanceOf(AnthropicClient);
   });
 });

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -1,7 +1,7 @@
 // AIService integration tests
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, AIService, buildUserInsightsMessages, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
+import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, AIService, buildUserInsightsMessages, generateUserInsightsSummary, USER_INSIGHTS_PROMPT_VERSION, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
 import { createMockKV, setupFetchMock } from '../utils/mocks';
 
 describe('OpenAIClient', () => {
@@ -424,5 +424,45 @@ describe('buildUserInsightsMessages', () => {
     const user = buildUserInsightsMessages(insightsSample)[1].content;
     expect(user).toContain('73');
     expect(user).toContain('Nostalgia Burns by Siiga');
+  });
+});
+
+describe('warmer-voice prompt', () => {
+  it('persona reacts to the music, not the listener', () => {
+    const system = buildUserInsightsMessages(insightsSample)[0].content;
+    expect(system.toLowerCase()).toContain('opinions about');
+    expect(system).not.toContain('pattern they might not have noticed');
+  });
+
+  it('bans the not-X-but-Y construction and caps em dashes', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).toContain('less like X, more like Y');
+    expect(user.toLowerCase()).toContain('em dash');
+  });
+
+  it('drops the atmosphere-seeding language', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).not.toContain('clear temperature');
+  });
+
+  it('exposes a prompt version for cache busting', () => {
+    expect(USER_INSIGHTS_PROMPT_VERSION).toBe('v2');
+  });
+});
+
+describe('generateUserInsightsSummary cache key', () => {
+  it('reads and writes the versioned cache key', async () => {
+    const mockKV = createMockKV();
+    const cache = new AICache(mockKV);
+    setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { model: 'claude-sonnet-4-6', content: [{ type: 'text', text: 'warm' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]);
+    await generateUserInsightsSummary('Bordesak', insightsSample, new AnthropicClient('k'), cache);
+    expect(mockKV.get).toHaveBeenCalledWith('ai:userInsightsSummary:bordesak:v2', 'json');
+    expect(mockKV.put).toHaveBeenCalledWith(
+      'ai:userInsightsSummary:bordesak:v2',
+      expect.any(String),
+      expect.any(Object)
+    );
   });
 });

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -353,6 +353,31 @@ describe('AnthropicClient.chatCompletion', () => {
     expect(lastBody(mockFetch).temperature).toBeUndefined();
   });
 
+  it('omits temperature for claude-sonnet-5 but keeps it for claude-sonnet-4-6', async () => {
+    const mkFetch = (model: string) =>
+      setupFetchMock([
+        { pattern: /api\.anthropic\.com/, response: { model, content: [{ type: 'text', text: 'x' }] } },
+      ]);
+
+    let mockFetch = mkFetch('claude-sonnet-5');
+    await new AnthropicClient('key').chatCompletion({
+      model: 'claude-sonnet-5',
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 1500,
+      temperature: 0.8,
+    });
+    expect(lastBody(mockFetch).temperature).toBeUndefined();
+
+    mockFetch = mkFetch('claude-sonnet-4-6');
+    await new AnthropicClient('key').chatCompletion({
+      model: 'claude-sonnet-4-6',
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 1500,
+      temperature: 0.8,
+    });
+    expect(lastBody(mockFetch).temperature).toBe(0.8);
+  });
+
   it('maps the response to content + anthropic metadata', async () => {
     setupFetchMock([
       {
@@ -480,8 +505,7 @@ describe('userInsightsSummary provider flip', () => {
   it('is configured for anthropic sonnet', () => {
     const cfg = getTaskConfig('userInsightsSummary');
     expect(cfg.provider).toBe('anthropic');
-    expect(cfg.model).toBe('claude-sonnet-4-6');
-    expect(cfg.temperature).toBe(0.8);
+    expect(cfg.model).toBe('claude-sonnet-5');
   });
 
   it('routes the task to the anthropic client', () => {

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -1,7 +1,7 @@
 // AIService integration tests
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, AIService, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
+import { OpenAIClient, AICache, AIRateLimiter, AnthropicClient, AIService, buildUserInsightsMessages, generateArtistSummary, generateArtistSentence } from '@listentomore/ai';
 import { createMockKV, setupFetchMock } from '../utils/mocks';
 
 describe('OpenAIClient', () => {
@@ -392,5 +392,37 @@ describe('AIService.getClientForTask', () => {
   it('exposes a constructed anthropic client', () => {
     const ai = makeService();
     expect(ai.anthropic).toBeInstanceOf(AnthropicClient);
+  });
+});
+
+const insightsSample = {
+  weeklyPlayCount: 73,
+  topArtists: [
+    { name: 'Siiga', playcount: 39 },
+    { name: 'Celer', playcount: 39 },
+  ],
+  topAlbums: [{ name: 'Nostalgia Burns', artist: 'Siiga', playcount: 39 }],
+  recentTracks: [{ name: 'Videotape', artist: 'Radiohead' }],
+  historicalArtists: [{ name: 'Celer' }, { name: 'Nils Frahm' }],
+};
+
+describe('buildUserInsightsMessages', () => {
+  it('returns a system message and a user message', () => {
+    const msgs = buildUserInsightsMessages(insightsSample);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].role).toBe('system');
+    expect(msgs[1].role).toBe('user');
+  });
+
+  it('annotates familiar vs new against the 6-month rotation', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).toContain('Celer: 39 plays (familiar)');
+    expect(user).toContain('Siiga: 39 plays (new for them)');
+  });
+
+  it('includes the weekly play count and a named album', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).toContain('73');
+    expect(user).toContain('Nostalgia Burns by Siiga');
   });
 });

--- a/apps/web/src/__tests__/services/ai.test.ts
+++ b/apps/web/src/__tests__/services/ai.test.ts
@@ -449,6 +449,14 @@ describe('warmer-voice prompt', () => {
   it('exposes a prompt version for cache busting', () => {
     expect(USER_INSIGHTS_PROMPT_VERSION).toBe('v2');
   });
+
+  it('embeds the hand-authored gold examples', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).toContain('When you fall into something, you fall all the way in.');
+    expect(user).toContain('Still the one, no argument.');
+    expect(user).toContain("No notes. That's a healthy week.");
+    expect(user).not.toContain('[PLACEHOLDER');
+  });
 });
 
 describe('generateUserInsightsSummary cache key', () => {

--- a/apps/web/src/api/internal/insights.ts
+++ b/apps/web/src/api/internal/insights.ts
@@ -204,6 +204,7 @@ app.get('/insights-ab', requireSessionAuth, async (c) => {
     const ai = c.get('ai') as AIService;
     const variants = [
       { key: 'gpt54', client: ai.openai, model: 'gpt-5.4', temperature: undefined as number | undefined },
+      { key: 'sonnet5', client: ai.anthropic, model: 'claude-sonnet-5', temperature: undefined as number | undefined },
       { key: 'sonnet46', client: ai.anthropic, model: 'claude-sonnet-4-6', temperature: 0.8 },
       { key: 'opus48', client: ai.anthropic, model: 'claude-opus-4-8', temperature: undefined as number | undefined },
     ];

--- a/apps/web/src/api/internal/insights.ts
+++ b/apps/web/src/api/internal/insights.ts
@@ -5,7 +5,7 @@ import { CACHE_CONFIG, getTtlSeconds } from '@listentomore/config';
 import { LastfmService } from '@listentomore/lastfm';
 import type { User } from '@listentomore/db';
 import type { AIService } from '@listentomore/ai';
-import { USER_INSIGHTS_PROMPT_VERSION } from '@listentomore/ai';
+import { USER_INSIGHTS_PROMPT_VERSION, buildUserInsightsMessages } from '@listentomore/ai';
 import type { SpotifyService } from '@listentomore/spotify';
 import type { Bindings, Variables } from '../../types';
 import { requireSessionAuth } from '../../middleware/require-session-auth';
@@ -164,6 +164,63 @@ app.get('/user-insights-summary', requireSessionAuth, async (c) => {
   } catch (error) {
     console.error('Internal user-insights-summary error:', error);
     return c.json({ error: 'Failed to generate insights' }, 500);
+  }
+});
+
+// Throwaway A/B comparison route for issue #32 — delete after picking a model.
+app.get('/insights-ab', requireSessionAuth, async (c) => {
+  const username = c.req.query('username');
+  if (!username) {
+    return c.json({ error: 'Missing username parameter' }, 400);
+  }
+
+  const accessResult = await getUserWithInsightsAccess(c, username);
+  if ('error' in accessResult) {
+    return c.json({ error: accessResult.error }, accessResult.status as 403 | 404);
+  }
+  const { lastfm } = accessResult;
+
+  try {
+    const [topArtists, topAlbums, recentTracks, historicalArtists] = await Promise.all([
+      lastfm.getTopArtists('7day', 5).catch(() => []),
+      lastfm.getTopAlbums('7day', 5).catch(() => []),
+      lastfm.recentTracks.getRecentTracks(30).catch(() => []),
+      lastfm.getTopArtists('6month', 20).catch(() => []),
+    ]);
+
+    const totalPlays = topArtists.reduce((sum, a) => sum + a.playcount, 0);
+    if (totalPlays < MIN_PLAYS_THRESHOLD) {
+      return c.json({ data: null, sparse: true });
+    }
+
+    const messages = buildUserInsightsMessages({
+      topArtists: topArtists.map((a) => ({ name: a.name, playcount: a.playcount })),
+      topAlbums: topAlbums.map((a) => ({ name: a.name, artist: a.artist, playcount: a.playcount })),
+      recentTracks: recentTracks.map((t) => ({ name: t.name, artist: t.artist })),
+      weeklyPlayCount: totalPlays,
+      historicalArtists: historicalArtists.map((a) => ({ name: a.name })),
+    });
+
+    const ai = c.get('ai') as AIService;
+    const variants = [
+      { key: 'gpt54', client: ai.openai, model: 'gpt-5.4', temperature: undefined as number | undefined },
+      { key: 'sonnet46', client: ai.anthropic, model: 'claude-sonnet-4-6', temperature: 0.8 },
+      { key: 'opus48', client: ai.anthropic, model: 'claude-opus-4-8', temperature: undefined as number | undefined },
+    ];
+
+    const results = await Promise.all(
+      variants.map((v) =>
+        v.client
+          .chatCompletion({ model: v.model, messages, maxTokens: 1500, temperature: v.temperature })
+          .then((r) => [v.key, r.content] as const)
+          .catch((e) => [v.key, `ERROR: ${e instanceof Error ? e.message : String(e)}`] as const)
+      )
+    );
+
+    return c.json({ data: Object.fromEntries(results) });
+  } catch (error) {
+    console.error('insights-ab error:', error);
+    return c.json({ error: 'Failed to generate A/B insights' }, 500);
   }
 });
 

--- a/apps/web/src/api/internal/insights.ts
+++ b/apps/web/src/api/internal/insights.ts
@@ -5,7 +5,7 @@ import { CACHE_CONFIG, getTtlSeconds } from '@listentomore/config';
 import { LastfmService } from '@listentomore/lastfm';
 import type { User } from '@listentomore/db';
 import type { AIService } from '@listentomore/ai';
-import { USER_INSIGHTS_PROMPT_VERSION, buildUserInsightsMessages } from '@listentomore/ai';
+import { USER_INSIGHTS_PROMPT_VERSION } from '@listentomore/ai';
 import type { SpotifyService } from '@listentomore/spotify';
 import type { Bindings, Variables } from '../../types';
 import { requireSessionAuth } from '../../middleware/require-session-auth';
@@ -164,64 +164,6 @@ app.get('/user-insights-summary', requireSessionAuth, async (c) => {
   } catch (error) {
     console.error('Internal user-insights-summary error:', error);
     return c.json({ error: 'Failed to generate insights' }, 500);
-  }
-});
-
-// Throwaway A/B comparison route for issue #32 — delete after picking a model.
-app.get('/insights-ab', requireSessionAuth, async (c) => {
-  const username = c.req.query('username');
-  if (!username) {
-    return c.json({ error: 'Missing username parameter' }, 400);
-  }
-
-  const accessResult = await getUserWithInsightsAccess(c, username);
-  if ('error' in accessResult) {
-    return c.json({ error: accessResult.error }, accessResult.status as 403 | 404);
-  }
-  const { lastfm } = accessResult;
-
-  try {
-    const [topArtists, topAlbums, recentTracks, historicalArtists] = await Promise.all([
-      lastfm.getTopArtists('7day', 5).catch(() => []),
-      lastfm.getTopAlbums('7day', 5).catch(() => []),
-      lastfm.recentTracks.getRecentTracks(30).catch(() => []),
-      lastfm.getTopArtists('6month', 20).catch(() => []),
-    ]);
-
-    const totalPlays = topArtists.reduce((sum, a) => sum + a.playcount, 0);
-    if (totalPlays < MIN_PLAYS_THRESHOLD) {
-      return c.json({ data: null, sparse: true });
-    }
-
-    const messages = buildUserInsightsMessages({
-      topArtists: topArtists.map((a) => ({ name: a.name, playcount: a.playcount })),
-      topAlbums: topAlbums.map((a) => ({ name: a.name, artist: a.artist, playcount: a.playcount })),
-      recentTracks: recentTracks.map((t) => ({ name: t.name, artist: t.artist })),
-      weeklyPlayCount: totalPlays,
-      historicalArtists: historicalArtists.map((a) => ({ name: a.name })),
-    });
-
-    const ai = c.get('ai') as AIService;
-    const variants = [
-      { key: 'gpt54', client: ai.openai, model: 'gpt-5.4', temperature: undefined as number | undefined },
-      { key: 'sonnet5', client: ai.anthropic, model: 'claude-sonnet-5', temperature: undefined as number | undefined },
-      { key: 'sonnet46', client: ai.anthropic, model: 'claude-sonnet-4-6', temperature: 0.8 },
-      { key: 'opus48', client: ai.anthropic, model: 'claude-opus-4-8', temperature: undefined as number | undefined },
-    ];
-
-    const results = await Promise.all(
-      variants.map((v) =>
-        v.client
-          .chatCompletion({ model: v.model, messages, maxTokens: 1500, temperature: v.temperature })
-          .then((r) => [v.key, r.content] as const)
-          .catch((e) => [v.key, `ERROR: ${e instanceof Error ? e.message : String(e)}`] as const)
-      )
-    );
-
-    return c.json({ data: Object.fromEntries(results) });
-  } catch (error) {
-    console.error('insights-ab error:', error);
-    return c.json({ error: 'Failed to generate A/B insights' }, 500);
   }
 });
 

--- a/apps/web/src/api/internal/insights.ts
+++ b/apps/web/src/api/internal/insights.ts
@@ -5,6 +5,7 @@ import { CACHE_CONFIG, getTtlSeconds } from '@listentomore/config';
 import { LastfmService } from '@listentomore/lastfm';
 import type { User } from '@listentomore/db';
 import type { AIService } from '@listentomore/ai';
+import { USER_INSIGHTS_PROMPT_VERSION } from '@listentomore/ai';
 import type { SpotifyService } from '@listentomore/spotify';
 import type { Bindings, Variables } from '../../types';
 import { requireSessionAuth } from '../../middleware/require-session-auth';
@@ -116,7 +117,11 @@ app.get('/user-insights-summary', requireSessionAuth, async (c) => {
 
     // Clear cache for this user
     const ai = c.get('ai') as AIService;
-    await ai.cache.delete('userInsightsSummary', username.toLowerCase());
+    await ai.cache.delete(
+      'userInsightsSummary',
+      username.toLowerCase(),
+      USER_INSIGHTS_PROMPT_VERSION
+    );
     await setRefreshTimestamp(c, username);
   }
 

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -131,6 +131,7 @@ app.use('*', async (c, next) => {
     'ai',
     new AIService({
       openaiApiKey: c.env.OPENAI_API_KEY,
+      anthropicApiKey: c.env.ANTHROPIC_API_KEY,
       cache: c.env.CACHE,
     })
   );
@@ -806,6 +807,7 @@ async function scheduled(
   if (minute < 5) {
     const ai = new AIService({
       openaiApiKey: env.OPENAI_API_KEY,
+      anthropicApiKey: env.ANTHROPIC_API_KEY,
       cache: env.CACHE,
     });
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -23,6 +23,7 @@ export type Bindings = {
   LASTFM_SHARED_SECRET?: string;
   LASTFM_USERNAME: string;
   OPENAI_API_KEY: string;
+  ANTHROPIC_API_KEY: string;
   YOUTUBE_API_KEY?: string;
   APPLE_TEAM_ID?: string;
   APPLE_KEY_ID?: string;

--- a/docs/superpowers/plans/2026-06-19-insights-warmer-voice.md
+++ b/docs/superpowers/plans/2026-06-19-insights-warmer-voice.md
@@ -1,0 +1,1076 @@
+# `/insights` Warmer Voice (few-shot + Claude) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the "Your Week in Music" `/insights` summary for a warmer, music-reacting voice (stance change + hand-authored few-shot examples) and run it on Claude (`claude-sonnet-4-6`) with an A/B route against GPT-5.4 and `claude-opus-4-8`.
+
+**Architecture:** Two parts. **C** adds an `AnthropicClient` (raw `fetch`, mirroring `OpenAIClient`) behind the existing `ChatClient` seam, registers an `anthropic` provider, and switches `getClientForTask` on `config.provider`. **A** rewrites the `userInsightsSummary` prompt: extract a pure `buildUserInsightsMessages` builder, change the persona from analyst→friend, cut the "Do NOT" wall to two structural bans, add hand-authored few-shot, drop the atmosphere framing, and bust the cache key. An internal A/B route runs all three models on the same week's data.
+
+**Tech Stack:** TypeScript, Hono on Cloudflare Workers, Turborepo + pnpm, Vitest.
+
+## Global Constraints
+
+- **Default model for `userInsightsSummary`:** `claude-sonnet-4-6` (Rian's explicit cost/latency call). `claude-opus-4-8` is the A/B ceiling test only.
+- **Exact model IDs, no date suffix:** `claude-sonnet-4-6`, `claude-opus-4-8`.
+- **`temperature` is rejected (400) on opus-tier** (`claude-opus-4-8`, `claude-opus-4-7`, `claude-fable-5`) — the adapter omits it there; passes it for `claude-sonnet-4-6`.
+- **Transport:** raw `fetch`/`fetchWithTimeout`, no `@anthropic-ai/sdk` dependency (mirror `OpenAIClient`).
+- **Anthropic auth headers:** `x-api-key`, `anthropic-version: 2023-06-01`, `Content-Type: application/json`. `max_tokens` required. `system` is a top-level param (not a message).
+- **Testing infrastructure (important — the AI package has NO test runner):** `@listentomore/ai` only has a `typecheck` script. All unit tests are added as new `describe` blocks in the **web** package's existing `apps/web/src/__tests__/services/ai.test.ts`, importing the units under test from `@listentomore/ai` (the package barrel) and `@listentomore/config`. **Anything a test imports from `@listentomore/ai` must first be re-exported from `packages/services/ai/src/index.ts`.** Use `createMockKV()` and `setupFetchMock([{ pattern, response, options? }])` from `apps/web/src/__tests__/utils/mocks.ts` (`setupFetchMock` mocks `globalThis.fetch` by URL regex and returns the mock fn; `options: { status, ok }` simulates errors; inspect requests via `mockFetch.mock.calls[0][1].body`). The file already does `import { describe, it, expect, vi, beforeEach } from 'vitest';` and imports from `@listentomore/ai` + `../utils/mocks` — **extend those existing import lines, don't add duplicates.** Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts`.
+- **Build order:** Tasks 1–7 are fully unblocked. **Task 8 is gated** on the owner's hand-authored examples (worksheet: `~/git/product-ai/05-personal/side-projects/listentomore/2026-06-19-insights-voice-examples-worksheet.md`). The feature is not shippable until Task 8 lands.
+- **Commits:** one per task; conventional-commit messages; first names only.
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `packages/config/src/ai.ts` | Modify | Register `AI_PROVIDERS.anthropic`, `RATE_LIMITS.anthropic`; later flip `userInsightsSummary`. |
+| `packages/services/ai/src/rate-limit.ts` | Modify | Widen `AIProvider`; use `RATE_LIMITS[provider]` for the limit. |
+| `packages/services/ai/src/types.ts` | Modify | Widen `AIResponseMetadata.provider` + `api`. |
+| `packages/services/ai/src/anthropic.ts` | Create | `AnthropicClient implements ChatClient`. |
+| `packages/services/ai/src/index.ts` | Modify | Export `AnthropicClient` + new prompt symbols; construct/expose `anthropic`; `getClientForTask` switch; `anthropicApiKey`. |
+| `packages/services/ai/src/prompts/user-insights-summary.ts` | Modify | Extract `buildUserInsightsMessages`; rewrite prompt; cache-version; few-shot. |
+| `packages/services/ai/src/prompts/index.ts` | Modify | Re-export the new prompt symbols. |
+| `apps/web/src/types.ts` | Modify | Add `ANTHROPIC_API_KEY` to `Bindings`. |
+| `apps/web/src/index.tsx` | Modify | Pass `anthropicApiKey` at both `AIService` sites (`:134`, `:809`). |
+| `apps/web/.dev.vars` | Modify | Add `ANTHROPIC_API_KEY` (value provided by owner). |
+| `apps/discord-bot/src/index.ts` | Modify | Add `ANTHROPIC_API_KEY` to `Env`; pass `anthropicApiKey` at the `AIService` site (`:75`). |
+| `apps/web/src/api/internal/insights.ts` | Modify | Add the A/B debug handler; bust the refresh-delete cache key. |
+| `apps/web/src/__tests__/services/ai.test.ts` | Modify | New `describe` blocks (Tasks 1–6, 8). |
+
+---
+
+### Task 1: Anthropic provider config + rate-limiter support
+
+**Files:**
+- Modify: `packages/config/src/ai.ts` (`AI_PROVIDERS`, `RATE_LIMITS`)
+- Modify: `packages/services/ai/src/rate-limit.ts:12,24`
+- Test: `apps/web/src/__tests__/services/ai.test.ts` (new `describe`)
+
+**Interfaces:**
+- Produces: `AI_PROVIDERS.anthropic = { baseUrl: 'https://api.anthropic.com/v1', defaultModel: 'claude-sonnet-4-6' }`; `RATE_LIMITS.anthropic = { requestsPerMinute: 50, tokensPerMinute: 40000 }`; `AIProvider = 'openai' | 'anthropic'`; `new AIRateLimiter(kv, 'anthropic')` reports `maxRequests: 50`.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the imports in `apps/web/src/__tests__/services/ai.test.ts` to add `AIRateLimiter` (from `@listentomore/ai`) and `createMockKV` (already imported), then append:
+
+```typescript
+describe('AIRateLimiter — provider-aware limits', () => {
+  it('uses the anthropic rate limit, not openai', async () => {
+    const rl = new AIRateLimiter(createMockKV(), 'anthropic');
+    const stats = await rl.getStats();
+    expect(stats.provider).toBe('anthropic');
+    expect(stats.maxRequests).toBe(50);
+  });
+
+  it('still reports the openai limit for the openai provider', async () => {
+    const rl = new AIRateLimiter(createMockKV(), 'openai');
+    expect((await rl.getStats()).maxRequests).toBe(90);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "provider-aware limits"`
+Expected: FAIL — `'anthropic'` not assignable to `AIProvider`, and/or `maxRequests` is `90` for both.
+
+- [ ] **Step 3: Add the provider + rate-limit config**
+
+In `packages/config/src/ai.ts`, add the `anthropic` entries:
+
+```typescript
+export const AI_PROVIDERS = {
+  openai: {
+    baseUrl: 'https://api.openai.com/v1',
+    defaultModel: 'gpt-5-mini',
+  },
+  anthropic: {
+    baseUrl: 'https://api.anthropic.com/v1',
+    defaultModel: 'claude-sonnet-4-6',
+  },
+} as const;
+```
+
+```typescript
+export const RATE_LIMITS = {
+  openai: {
+    requestsPerMinute: 90,
+    tokensPerMinute: 90000,
+  },
+  anthropic: {
+    requestsPerMinute: 50,
+    tokensPerMinute: 40000,
+  },
+  spotify: {
+    requestsPerMinute: 150,
+    maxRetries: 2,
+    retryDelayMs: 1000,
+  },
+} as const;
+```
+
+- [ ] **Step 4: Make the rate limiter provider-aware**
+
+In `packages/services/ai/src/rate-limit.ts`, widen the type (line 12) and fix the limit lookup (line 24):
+
+```typescript
+export type AIProvider = 'openai' | 'anthropic';
+```
+
+```typescript
+  constructor(
+    private cache: KVNamespace,
+    private provider: AIProvider
+  ) {
+    this.cacheKey = `ai:ratelimit:${provider}`;
+    this.maxRequests = RATE_LIMITS[provider].requestsPerMinute;
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "provider-aware limits"`
+Expected: PASS (both cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/config/src/ai.ts packages/services/ai/src/rate-limit.ts apps/web/src/__tests__/services/ai.test.ts
+git commit -m "feat(ai): register anthropic provider + make rate limiter provider-aware"
+```
+
+---
+
+### Task 2: `AnthropicClient` + metadata type + barrel export
+
+**Files:**
+- Modify: `packages/services/ai/src/types.ts:41,45` (`AIResponseMetadata`)
+- Create: `packages/services/ai/src/anthropic.ts`
+- Modify: `packages/services/ai/src/index.ts` (re-export `AnthropicClient`)
+- Test: `apps/web/src/__tests__/services/ai.test.ts` (new `describe`)
+
+**Interfaces:**
+- Consumes: `ChatClient`, `ChatCompletionOptions`, `ChatCompletionResponse`, `AIResponseMetadata` from `./types`; `AIRateLimiter` from `./rate-limit`; `fetchWithTimeout` from `@listentomore/shared`; `AI_PROVIDERS` from `@listentomore/config`.
+- Produces: `class AnthropicClient implements ChatClient` with `constructor(apiKey: string, rateLimiter?: AIRateLimiter)` and `chatCompletion(options): Promise<ChatCompletionResponse>` (metadata `provider: 'anthropic'`, `api: 'messages'`); re-exported from `@listentomore/ai`.
+
+- [ ] **Step 1: Widen the metadata type**
+
+In `packages/services/ai/src/types.ts`, change the `provider` and `api` fields of `AIResponseMetadata`:
+
+```typescript
+  /** Provider that handled the request */
+  provider: 'openai' | 'anthropic';
+  /** Actual model used (from API response) */
+  model: string;
+  /** Which API was used */
+  api: 'responses' | 'chat_completions' | 'messages';
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Extend the test-file imports to add `AnthropicClient` (from `@listentomore/ai`) and `setupFetchMock` (from `../utils/mocks`), then append:
+
+```typescript
+describe('AnthropicClient.chatCompletion', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function lastBody(mockFetch: ReturnType<typeof setupFetchMock>) {
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    return JSON.parse(init.body as string);
+  }
+
+  it('extracts the system message to the top-level system param', async () => {
+    const mockFetch = setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { model: 'claude-sonnet-4-6', content: [{ type: 'text', text: 'hi' }] } },
+    ]);
+    await new AnthropicClient('key').chatCompletion({
+      model: 'claude-sonnet-4-6',
+      messages: [
+        { role: 'system', content: 'You are a friend.' },
+        { role: 'user', content: 'My week...' },
+      ],
+      maxTokens: 1500,
+      temperature: 0.8,
+    });
+    const body = lastBody(mockFetch);
+    expect(body.system).toBe('You are a friend.');
+    expect(body.messages).toEqual([{ role: 'user', content: 'My week...' }]);
+    expect(body.max_tokens).toBe(1500);
+    expect(body.temperature).toBe(0.8);
+  });
+
+  it('omits temperature for opus-tier models', async () => {
+    const mockFetch = setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { model: 'claude-opus-4-8', content: [{ type: 'text', text: 'x' }] } },
+    ]);
+    await new AnthropicClient('key').chatCompletion({
+      model: 'claude-opus-4-8',
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 1500,
+      temperature: 0.8,
+    });
+    expect(lastBody(mockFetch).temperature).toBeUndefined();
+  });
+
+  it('maps the response to content + anthropic metadata', async () => {
+    setupFetchMock([
+      {
+        pattern: /api\.anthropic\.com/,
+        response: { model: 'claude-sonnet-4-6', content: [{ type: 'text', text: 'warm summary' }], usage: { input_tokens: 100, output_tokens: 50 } },
+      },
+    ]);
+    const res = await new AnthropicClient('key').chatCompletion({
+      model: 'claude-sonnet-4-6',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(res.content).toBe('warm summary');
+    expect(res.metadata?.provider).toBe('anthropic');
+    expect(res.metadata?.api).toBe('messages');
+    expect(res.metadata?.usage).toEqual({ inputTokens: 100, outputTokens: 50, totalTokens: 150 });
+  });
+
+  it('throws on a non-200 response', async () => {
+    setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { error: 'bad' }, options: { status: 400, ok: false } },
+    ]);
+    await expect(
+      new AnthropicClient('key').chatCompletion({ model: 'claude-sonnet-4-6', messages: [{ role: 'user', content: 'hi' }] })
+    ).rejects.toThrow('Anthropic API error');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "AnthropicClient"`
+Expected: FAIL — `AnthropicClient` is not exported from `@listentomore/ai`.
+
+- [ ] **Step 4: Write the `AnthropicClient`**
+
+```typescript
+// packages/services/ai/src/anthropic.ts
+// ABOUTME: Anthropic (Claude) API client mirroring the OpenAIClient shape.
+// ABOUTME: Calls POST /v1/messages via raw fetch; no SDK dependency.
+
+import { AI_PROVIDERS } from '@listentomore/config';
+import { fetchWithTimeout } from '@listentomore/shared';
+import type {
+  ChatClient,
+  ChatCompletionOptions,
+  ChatCompletionResponse,
+  AIResponseMetadata,
+} from './types';
+import type { AIRateLimiter } from './rate-limit';
+
+const ANTHROPIC_VERSION = '2023-06-01';
+
+// Opus-tier (4.7+) and Fable 5 reject sampling params with a 400.
+const MODELS_WITHOUT_TEMPERATURE = [
+  'claude-opus-4-8',
+  'claude-opus-4-7',
+  'claude-fable-5',
+];
+
+export class AnthropicClient implements ChatClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private rateLimiter: AIRateLimiter | null;
+
+  constructor(apiKey: string, rateLimiter?: AIRateLimiter) {
+    this.apiKey = apiKey;
+    this.baseUrl = AI_PROVIDERS.anthropic.baseUrl;
+    this.rateLimiter = rateLimiter ?? null;
+  }
+
+  async chatCompletion(
+    options: ChatCompletionOptions
+  ): Promise<ChatCompletionResponse> {
+    if (this.rateLimiter) {
+      await this.rateLimiter.acquire();
+    }
+
+    // Anthropic takes the system prompt as a top-level param, not a message.
+    const systemMessage = options.messages.find((m) => m.role === 'system');
+    const conversation = options.messages.filter((m) => m.role !== 'system');
+
+    const body: Record<string, unknown> = {
+      model: options.model,
+      max_tokens: options.maxTokens ?? 1500,
+      messages: conversation.map((m) => ({ role: m.role, content: m.content })),
+    };
+    if (systemMessage) {
+      body.system = systemMessage.content;
+    }
+    // Only send temperature where the model supports it.
+    if (
+      options.temperature !== undefined &&
+      !MODELS_WITHOUT_TEMPERATURE.some((m) => options.model.startsWith(m))
+    ) {
+      body.temperature = options.temperature;
+    }
+
+    const response = await fetchWithTimeout(`${this.baseUrl}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify(body),
+      timeout: 'slow', // 30 seconds for AI
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error(`[Anthropic] API error: ${response.status} - ${errorBody}`);
+      throw new Error(`Anthropic API error: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      model: string;
+      content: Array<{ type: string; text?: string }>;
+      usage?: { input_tokens?: number; output_tokens?: number };
+    };
+
+    const content = data.content
+      .filter((b) => b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text)
+      .join('');
+
+    const metadata: AIResponseMetadata = {
+      provider: 'anthropic',
+      model: data.model,
+      api: 'messages',
+      usage: data.usage
+        ? {
+            inputTokens: data.usage.input_tokens ?? null,
+            outputTokens: data.usage.output_tokens ?? null,
+            totalTokens:
+              (data.usage.input_tokens ?? 0) + (data.usage.output_tokens ?? 0) ||
+              null,
+          }
+        : undefined,
+    };
+
+    return { content, metadata };
+  }
+}
+```
+
+- [ ] **Step 5: Re-export from the barrel**
+
+In `packages/services/ai/src/index.ts`, add the re-export next to the existing `export { OpenAIClient } from './openai';`:
+
+```typescript
+export { AnthropicClient } from './anthropic';
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "AnthropicClient"`
+Expected: PASS (4 cases). Then `pnpm typecheck` — PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/services/ai/src/anthropic.ts packages/services/ai/src/types.ts packages/services/ai/src/index.ts apps/web/src/__tests__/services/ai.test.ts
+git commit -m "feat(ai): add AnthropicClient (raw fetch, ChatClient impl)"
+```
+
+---
+
+### Task 3: Wire `AnthropicClient` into `AIService` + all call sites
+
+**Files:**
+- Modify: `packages/services/ai/src/index.ts` (import `getTaskConfig`, `AIServiceConfig`, constructor, `getClientForTask`)
+- Modify: `apps/web/src/types.ts:27` (add `ANTHROPIC_API_KEY`)
+- Modify: `apps/web/src/index.tsx:134,809` (pass `anthropicApiKey`)
+- Modify: `apps/discord-bot/src/index.ts:35,75` (Env + construction)
+- Modify: `apps/web/.dev.vars` (add `ANTHROPIC_API_KEY` — value provided by owner)
+- Test: `apps/web/src/__tests__/services/ai.test.ts` (new `describe`)
+
+**Interfaces:**
+- Consumes: `AnthropicClient` (Task 2); `getTaskConfig`, `AITask` from `@listentomore/config`.
+- Produces: `AIService.anthropic: AnthropicClient` (public); `AIServiceConfig.anthropicApiKey: string`; `getClientForTask(task)` returns `this.anthropic` when `getTaskConfig(task).provider === 'anthropic'`, else `this.openai`.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the imports to add `AIService` (from `@listentomore/ai`). Append:
+
+```typescript
+describe('AIService.getClientForTask', () => {
+  function makeService() {
+    return new AIService({ openaiApiKey: 'o', anthropicApiKey: 'a', cache: createMockKV() });
+  }
+
+  it('returns the OpenAI client for an openai-provider task', () => {
+    const ai = makeService();
+    expect(ai.getClientForTask('artistSummary')).toBe(ai.openai);
+  });
+
+  it('exposes a constructed anthropic client', () => {
+    const ai = makeService();
+    expect(ai.anthropic).toBeInstanceOf(AnthropicClient);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "getClientForTask"`
+Expected: FAIL — `AIServiceConfig` has no `anthropicApiKey` / `ai.anthropic` undefined.
+
+- [ ] **Step 3: Wire the client into `AIService`**
+
+In `packages/services/ai/src/index.ts`:
+
+**Modify the existing config import line** `import type { AITask } from '@listentomore/config';` to import the value `getTaskConfig` too (it becomes a regular import with an inline type):
+
+```typescript
+import { getTaskConfig, type AITask } from '@listentomore/config';
+```
+
+Add the client import next to the existing `import { OpenAIClient } from './openai';`:
+
+```typescript
+import { AnthropicClient } from './anthropic';
+```
+
+Extend the config and class:
+
+```typescript
+export interface AIServiceConfig {
+  openaiApiKey: string;
+  anthropicApiKey: string;
+  cache: KVNamespace;
+}
+```
+
+```typescript
+export class AIService {
+  public readonly openai: OpenAIClient;
+  public readonly anthropic: AnthropicClient;
+  public readonly cache: AICache;
+  public readonly kv: KVNamespace;
+  public readonly openaiRateLimiter: AIRateLimiter;
+  public readonly anthropicRateLimiter: AIRateLimiter;
+
+  constructor(config: AIServiceConfig) {
+    this.openaiRateLimiter = new AIRateLimiter(config.cache, 'openai');
+    this.anthropicRateLimiter = new AIRateLimiter(config.cache, 'anthropic');
+    this.openai = new OpenAIClient(config.openaiApiKey, this.openaiRateLimiter);
+    this.anthropic = new AnthropicClient(
+      config.anthropicApiKey,
+      this.anthropicRateLimiter
+    );
+    this.cache = new AICache(config.cache);
+    this.kv = config.cache;
+  }
+
+  /**
+   * Get the appropriate client for a task based on config.provider.
+   */
+  getClientForTask(task: AITask): ChatClient {
+    const { provider } = getTaskConfig(task);
+    return provider === 'anthropic' ? this.anthropic : this.openai;
+  }
+  // ...rest of the class unchanged
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "getClientForTask"`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Update the three `AIService` construction sites + bindings**
+
+`apps/web/src/types.ts` — add to the `Bindings` interface (next to `OPENAI_API_KEY` at line 27):
+
+```typescript
+  ANTHROPIC_API_KEY: string;
+```
+
+`apps/web/src/index.tsx` — read each `new AIService({ ... })` site first, then add **only** the `anthropicApiKey` line, keeping the surrounding fields. At `:134` the env handle is `c.env`; at `:809` it is `env`:
+
+```typescript
+    // site ~134
+    new AIService({
+      openaiApiKey: c.env.OPENAI_API_KEY,
+      anthropicApiKey: c.env.ANTHROPIC_API_KEY,
+      cache: c.env.CACHE,
+    })
+```
+
+```typescript
+    // site ~809
+    const ai = new AIService({
+      openaiApiKey: env.OPENAI_API_KEY,
+      anthropicApiKey: env.ANTHROPIC_API_KEY,
+      cache: env.CACHE,
+    });
+```
+
+`apps/discord-bot/src/index.ts` — add `ANTHROPIC_API_KEY: string;` to the `Env` interface (next to `OPENAI_API_KEY` at line 35), and add `anthropicApiKey: env.ANTHROPIC_API_KEY,` at the `new AIService({ ... })` site (line 75). Read the site first; keep its existing `cache:` field as-is.
+
+`apps/web/.dev.vars` — add a line (the owner supplies the real value):
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**Owner action (cannot be automated):** put the real key in `apps/web/.dev.vars`, and set the prod secret: `cd apps/web && npx wrangler secret put ANTHROPIC_API_KEY`. (The discord-bot only needs its own `ANTHROPIC_API_KEY` secret if it ever runs an anthropic-provider task — none today.)
+
+- [ ] **Step 6: Typecheck the whole repo**
+
+Run: `pnpm typecheck`
+Expected: PASS — no missing-property errors at any `AIService` site.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/services/ai/src/index.ts apps/web/src/types.ts apps/web/src/index.tsx apps/discord-bot/src/index.ts apps/web/.dev.vars apps/web/src/__tests__/services/ai.test.ts
+git commit -m "feat(ai): wire AnthropicClient into AIService + provider-based client selection"
+```
+
+---
+
+### Task 4: Extract `buildUserInsightsMessages` (behavior-preserving)
+
+**Files:**
+- Modify: `packages/services/ai/src/prompts/user-insights-summary.ts`
+- Modify: `packages/services/ai/src/prompts/index.ts` + `packages/services/ai/src/index.ts` (re-export `buildUserInsightsMessages`)
+- Test: `apps/web/src/__tests__/services/ai.test.ts` (new `describe`)
+
+**Interfaces:**
+- Produces: `export function buildUserInsightsMessages(listeningData: ListeningData): ChatMessage[]` — returns `[systemMessage, userMessage]`; re-exported from `@listentomore/ai`. Moves the familiar/new annotation + slicing out of `generateUserInsightsSummary`, which now calls the builder.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend imports to add `buildUserInsightsMessages` (from `@listentomore/ai`). Add a shared `sample` fixture (module scope, reused by Tasks 5/8) and the block:
+
+```typescript
+const insightsSample = {
+  weeklyPlayCount: 73,
+  topArtists: [
+    { name: 'Siiga', playcount: 39 },
+    { name: 'Celer', playcount: 39 },
+  ],
+  topAlbums: [{ name: 'Nostalgia Burns', artist: 'Siiga', playcount: 39 }],
+  recentTracks: [{ name: 'Videotape', artist: 'Radiohead' }],
+  historicalArtists: [{ name: 'Celer' }, { name: 'Nils Frahm' }],
+};
+
+describe('buildUserInsightsMessages', () => {
+  it('returns a system message and a user message', () => {
+    const msgs = buildUserInsightsMessages(insightsSample);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].role).toBe('system');
+    expect(msgs[1].role).toBe('user');
+  });
+
+  it('annotates familiar vs new against the 6-month rotation', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).toContain('Celer: 39 plays (familiar)');
+    expect(user).toContain('Siiga: 39 plays (new for them)');
+  });
+
+  it('includes the weekly play count and a named album', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).toContain('73');
+    expect(user).toContain('Nostalgia Burns by Siiga');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "buildUserInsightsMessages"`
+Expected: FAIL — not exported from `@listentomore/ai`.
+
+- [ ] **Step 3: Extract the builder (preserve current prompt text)**
+
+In `packages/services/ai/src/prompts/user-insights-summary.ts`, add `ChatMessage` to the existing type import, and export a builder holding the **current** system + user prompt (verbatim move — no wording change yet):
+
+```typescript
+import type { ChatClient, ChatMessage, AIResponseMetadata } from '../types';
+```
+
+```typescript
+const SYSTEM_PROMPT =
+  "You're a friend who pays attention to what people listen to. When someone shares their week, you find the one thing that's actually interesting about it — not the obvious summary, but the pattern they might not have noticed themselves. You know their usual rotation and what's new for them. You write like a person, not a report: one sharp observation, specific and earned.";
+
+/**
+ * Build the chat messages for the weekly insights summary.
+ * Pure — no cache, no client. Shared by generate + the A/B route.
+ */
+export function buildUserInsightsMessages(
+  listeningData: ListeningData
+): ChatMessage[] {
+  const {
+    topArtists,
+    topAlbums,
+    recentTracks,
+    weeklyPlayCount,
+    historicalArtists,
+  } = listeningData;
+
+  const historicalNames = new Set(
+    historicalArtists.map((a) => a.name.toLowerCase())
+  );
+  const annotatedArtists = topArtists.map((a) => ({
+    ...a,
+    isRegular: historicalNames.has(a.name.toLowerCase()),
+  }));
+
+  const topArtistsSlice = annotatedArtists.slice(0, 5);
+  const topAlbumsSlice = topAlbums.slice(0, 5);
+  const recentTracksSlice = recentTracks.slice(0, 30);
+
+  const userPrompt = `Here's someone's listening from the past week. Find the one thing about it that's genuinely interesting — the pattern a friend who knows their taste would call out, not a recap.
+
+Total plays this week: ${weeklyPlayCount}
+
+Top artists this week:
+${topArtistsSlice.map((a) => `- ${a.name}: ${a.playcount} plays${a.isRegular ? ' (familiar)' : ' (new for them)'}`).join('\n')}
+
+Top albums this week:
+${topAlbumsSlice.map((a) => `- ${a.name} by ${a.artist}: ${a.playcount} plays`).join('\n')}
+
+Recent tracks (most recent first):
+${recentTracksSlice.map((t) => `- ${t.name} — ${t.artist}`).join('\n') || '- (none on record)'}
+
+Their rotation over the past 6 months: ${historicalArtists.map((a) => a.name).join(', ') || 'none on record'}
+
+Things worth looking for — pick ONE, don't try to cover everything:
+- An obsession: one artist or album eating the week
+- A rabbit hole: a thread from one artist, scene, or era to another
+- A return: coming back to something they hadn't played in a while
+- A break: stepping outside their usual rotation
+- A mood: the week has a clear temperature, even across different artists
+- A contrast: the gap between what they're usually into and what this week actually was
+
+Write 2 to 3 short paragraphs in second person. Give the observation room to breathe: set it up, show the evidence in the tracks and albums, land the point. Name specific artists, albums, or tracks. Use the familiar/new flags.
+
+Open with a direct observation — something concrete that's actually in their week. Do NOT open with a rhetorical hook ("The interesting thing is...", "What stands out is...", "Here's what's notable..."). Do NOT open with "Based on your listening" or "This week you listened to." Start in the scene, not above it.
+
+You can be a little writerly if the observation earns it, but no clichés, no recommendations. If the week is genuinely unremarkable — mostly their usual rotation without much variation — say that plainly, then find the small thing that's still worth noting.`;
+
+  return [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: userPrompt },
+  ];
+}
+```
+
+Then replace the inline prompt construction inside `generateUserInsightsSummary` so it calls the builder (delete the now-duplicated annotation/slice/`prompt` block):
+
+```typescript
+  const config = getTaskConfig('userInsightsSummary');
+  const messages = buildUserInsightsMessages(listeningData);
+
+  const response = await client.chatCompletion({
+    model: config.model,
+    messages,
+    maxTokens: config.maxTokens,
+    temperature: config.temperature,
+    reasoning: config.reasoning,
+    verbosity: config.verbosity,
+  });
+```
+
+- [ ] **Step 4: Re-export the builder**
+
+In `packages/services/ai/src/prompts/index.ts`, ensure `buildUserInsightsMessages` is re-exported from `./user-insights-summary` (add it to the existing export list). Then in `packages/services/ai/src/index.ts`, add `buildUserInsightsMessages` to the existing `export { ... } from './prompts';` block (next to `generateUserInsightsSummary`).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "buildUserInsightsMessages"`
+Expected: PASS (3 cases). Then `pnpm --filter @listentomore/web test` — full suite green (no regressions). Then `pnpm typecheck` — PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/services/ai/src/prompts/user-insights-summary.ts packages/services/ai/src/prompts/index.ts packages/services/ai/src/index.ts apps/web/src/__tests__/services/ai.test.ts
+git commit -m "refactor(ai): extract pure buildUserInsightsMessages from the insights summary"
+```
+
+---
+
+### Task 5: Rewrite the prompt (warmer voice) + bust the cache key
+
+**Files:**
+- Modify: `packages/services/ai/src/prompts/user-insights-summary.ts`
+- Modify: `packages/services/ai/src/prompts/index.ts` + `packages/services/ai/src/index.ts` (re-export `USER_INSIGHTS_PROMPT_VERSION`)
+- Modify: `apps/web/src/api/internal/insights.ts:119` (versioned refresh-delete)
+- Test: `apps/web/src/__tests__/services/ai.test.ts` (new `describe`)
+
+**Interfaces:**
+- Produces: `export const USER_INSIGHTS_PROMPT_VERSION = 'v2'` (re-exported from `@listentomore/ai`); the cache key for this task becomes `ai:userInsightsSummary:<username>:v2`. The system persona reacts to the *music*; the user prompt carries the two structural bans, an example slot, and no atmosphere framing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend imports to add `USER_INSIGHTS_PROMPT_VERSION`, `generateUserInsightsSummary` (from `@listentomore/ai`) and `AICache` (already imported). Append:
+
+```typescript
+describe('warmer-voice prompt', () => {
+  it('persona reacts to the music, not the listener', () => {
+    const system = buildUserInsightsMessages(insightsSample)[0].content;
+    expect(system.toLowerCase()).toContain('opinions about');
+    expect(system).not.toContain('pattern they might not have noticed');
+  });
+
+  it('bans the not-X-but-Y construction and caps em dashes', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).toContain('less like X, more like Y');
+    expect(user.toLowerCase()).toContain('em dash');
+  });
+
+  it('drops the atmosphere-seeding language', () => {
+    const user = buildUserInsightsMessages(insightsSample)[1].content;
+    expect(user).not.toContain('clear temperature');
+  });
+
+  it('exposes a prompt version for cache busting', () => {
+    expect(USER_INSIGHTS_PROMPT_VERSION).toBe('v2');
+  });
+});
+
+describe('generateUserInsightsSummary cache key', () => {
+  it('reads and writes the versioned cache key', async () => {
+    const mockKV = createMockKV();
+    const cache = new AICache(mockKV);
+    setupFetchMock([
+      { pattern: /api\.anthropic\.com/, response: { model: 'claude-sonnet-4-6', content: [{ type: 'text', text: 'warm' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]);
+    await generateUserInsightsSummary('Bordesak', insightsSample, new AnthropicClient('k'), cache);
+    expect(mockKV.get).toHaveBeenCalledWith('ai:userInsightsSummary:bordesak:v2', 'json');
+    expect(mockKV.put).toHaveBeenCalledWith(
+      'ai:userInsightsSummary:bordesak:v2',
+      expect.any(String),
+      expect.any(Object)
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "warmer-voice prompt"`
+Expected: FAIL — old persona present, no bans, no version export, unversioned cache key.
+
+- [ ] **Step 3: Rewrite the persona + user prompt**
+
+Replace `SYSTEM_PROMPT`:
+
+```typescript
+const SYSTEM_PROMPT =
+  "You're a friend who pays attention to what people listen to. When someone shows you their week, you react to the music itself — you have opinions about records and songs, the ones you love, the ones that surprised you, the stuff you'd text them about. You know their usual rotation and what's new for them. You're not analyzing them; you're talking about the music with someone whose taste you know.";
+```
+
+Add the example-slot constant **above** the builder (placeholder until Task 8):
+
+```typescript
+// Hand-authored gold-standard examples in the owner's voice. Filled in Task 8
+// from the worksheet. Until then this is a single neutral placeholder so the
+// structure compiles and the bans/voice are exercised by tests.
+const FEW_SHOT_EXAMPLES = `Here are a couple of summaries in the right voice (one with the data it came from, then two on their own):
+
+[PLACEHOLDER — replace with the owner's hand-authored examples in Task 8]`;
+```
+
+Replace the instruction tail of `userPrompt` (everything from "Things worth looking for" onward) with the new instructions + example slot. Keep the data blocks above it exactly:
+
+```typescript
+Their rotation over the past 6 months: ${historicalArtists.map((a) => a.name).join(', ') || 'none on record'}
+
+${FEW_SHOT_EXAMPLES}
+
+Now write theirs. 2 to 3 short paragraphs, second person. React to the music with at least one real opinion about a song or record — not a description of the listener. Name specific artists, albums, or tracks, and use the familiar/new flags. If the week is mostly their usual rotation, say so plainly, then find the small thing still worth noting.
+
+Hard rules:
+- Never use "not X — but Y", "it isn't X, it's Y", or "less like X, more like Y" anywhere. This is the move to avoid.
+- At most 3 em dashes in the whole thing.
+- No clichés, no recommendations, no mood/atmosphere adjectives standing in for an actual observation.`;
+```
+
+Add the version export at the top of the module:
+
+```typescript
+export const USER_INSIGHTS_PROMPT_VERSION = 'v2';
+```
+
+Version the cache get/set inside `generateUserInsightsSummary`:
+
+```typescript
+  const cached = await cache.get<UserInsightsSummaryResult>(
+    'userInsightsSummary',
+    normalizedUsername,
+    USER_INSIGHTS_PROMPT_VERSION
+  );
+  if (cached) {
+    return cached;
+  }
+```
+
+```typescript
+  await cache.set(
+    'userInsightsSummary',
+    [normalizedUsername, USER_INSIGHTS_PROMPT_VERSION],
+    { content: result.content }
+  );
+```
+
+- [ ] **Step 4: Re-export the version + version the refresh-delete**
+
+In `packages/services/ai/src/prompts/index.ts` re-export `USER_INSIGHTS_PROMPT_VERSION` from `./user-insights-summary`; in `packages/services/ai/src/index.ts` add it to the `export { ... } from './prompts';` block.
+
+In `apps/web/src/api/internal/insights.ts`, import the version and update the delete at line 119:
+
+```typescript
+import { USER_INSIGHTS_PROMPT_VERSION } from '@listentomore/ai';
+```
+
+```typescript
+    await ai.cache.delete(
+      'userInsightsSummary',
+      username.toLowerCase(),
+      USER_INSIGHTS_PROMPT_VERSION
+    );
+```
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "warmer-voice prompt"` then `-t "cache key"`
+Expected: PASS. Then `pnpm typecheck` — PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/services/ai/src/prompts/user-insights-summary.ts packages/services/ai/src/prompts/index.ts packages/services/ai/src/index.ts apps/web/src/api/internal/insights.ts apps/web/src/__tests__/services/ai.test.ts
+git commit -m "feat(insights): warmer music-reacting persona + structural bans + cache bust"
+```
+
+---
+
+### Task 6: Flip `userInsightsSummary` to Claude
+
+**Files:**
+- Modify: `packages/config/src/ai.ts` (`userInsightsSummary` block)
+- Test: `apps/web/src/__tests__/services/ai.test.ts` (new `describe`)
+
+**Interfaces:**
+- Produces: `getTaskConfig('userInsightsSummary')` → `{ provider: 'anthropic', model: 'claude-sonnet-4-6', temperature: 0.8, maxTokens: 1500, cacheTtlDays: 1 }`; `getClientForTask('userInsightsSummary')` returns the anthropic client.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend imports to add `getTaskConfig` (from `@listentomore/config`). Append:
+
+```typescript
+describe('userInsightsSummary provider flip', () => {
+  it('is configured for anthropic sonnet', () => {
+    const cfg = getTaskConfig('userInsightsSummary');
+    expect(cfg.provider).toBe('anthropic');
+    expect(cfg.model).toBe('claude-sonnet-4-6');
+    expect(cfg.temperature).toBe(0.8);
+  });
+
+  it('routes the task to the anthropic client', () => {
+    const ai = new AIService({ openaiApiKey: 'o', anthropicApiKey: 'a', cache: createMockKV() });
+    expect(ai.getClientForTask('userInsightsSummary')).toBe(ai.anthropic);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "provider flip"`
+Expected: FAIL — provider still `'openai'`, model `gpt-5.4`.
+
+- [ ] **Step 3: Flip the config**
+
+In `packages/config/src/ai.ts`, replace the `userInsightsSummary` block (drops `verbosity` — OpenAI-only):
+
+```typescript
+  userInsightsSummary: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    maxTokens: 1500,
+    temperature: 0.8,
+    cacheTtlDays: 1,
+  },
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "provider flip"`
+Expected: PASS. Then `pnpm typecheck` — PASS (`satisfies Record<string, AITaskConfig>` holds).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/config/src/ai.ts apps/web/src/__tests__/services/ai.test.ts
+git commit -m "feat(insights): route userInsightsSummary to claude-sonnet-4-6"
+```
+
+---
+
+### Task 7: Internal A/B debug route
+
+**Files:**
+- Modify: `apps/web/src/api/internal/insights.ts` (new handler `GET /insights-ab`)
+
+**Interfaces:**
+- Consumes: `getUserWithInsightsAccess` (existing in the file), `buildUserInsightsMessages` from `@listentomore/ai`, `c.get('ai')`.
+- Produces: `GET /api/internal/insights-ab?username=X` → `{ data: { gpt54, sonnet46, opus48 } }`, cache-bypassed, owner/privacy-gated. Throwaway scaffolding.
+
+> **Testing note:** there is no existing internal-route test harness (the internal handlers rely on middleware-set context: `c.get('ai')`, `c.get('db')`, `c.get('currentUser')`). Building a context mock for a route that gets deleted is not worth it — this route is verified **manually** in Task 8 Step 5 against `pnpm dev`. No automated test for this task.
+
+- [ ] **Step 1: Add the A/B handler**
+
+In `apps/web/src/api/internal/insights.ts`, add the builder import and a handler after the existing `/user-insights-summary` route:
+
+```typescript
+import { buildUserInsightsMessages } from '@listentomore/ai';
+```
+
+```typescript
+// Throwaway A/B comparison route for issue #32 — delete after picking a model.
+app.get('/insights-ab', requireSessionAuth, async (c) => {
+  const username = c.req.query('username');
+  if (!username) {
+    return c.json({ error: 'Missing username parameter' }, 400);
+  }
+
+  const accessResult = await getUserWithInsightsAccess(c, username);
+  if ('error' in accessResult) {
+    return c.json({ error: accessResult.error }, accessResult.status as 403 | 404);
+  }
+  const { lastfm } = accessResult;
+
+  try {
+    const [topArtists, topAlbums, recentTracks, historicalArtists] = await Promise.all([
+      lastfm.getTopArtists('7day', 5).catch(() => []),
+      lastfm.getTopAlbums('7day', 5).catch(() => []),
+      lastfm.recentTracks.getRecentTracks(30).catch(() => []),
+      lastfm.getTopArtists('6month', 20).catch(() => []),
+    ]);
+
+    const totalPlays = topArtists.reduce((sum, a) => sum + a.playcount, 0);
+    if (totalPlays < MIN_PLAYS_THRESHOLD) {
+      return c.json({ data: null, sparse: true });
+    }
+
+    const messages = buildUserInsightsMessages({
+      topArtists: topArtists.map((a) => ({ name: a.name, playcount: a.playcount })),
+      topAlbums: topAlbums.map((a) => ({ name: a.name, artist: a.artist, playcount: a.playcount })),
+      recentTracks: recentTracks.map((t) => ({ name: t.name, artist: t.artist })),
+      weeklyPlayCount: totalPlays,
+      historicalArtists: historicalArtists.map((a) => ({ name: a.name })),
+    });
+
+    const ai = c.get('ai') as AIService;
+    const variants = [
+      { key: 'gpt54', client: ai.openai, model: 'gpt-5.4', temperature: undefined as number | undefined },
+      { key: 'sonnet46', client: ai.anthropic, model: 'claude-sonnet-4-6', temperature: 0.8 },
+      { key: 'opus48', client: ai.anthropic, model: 'claude-opus-4-8', temperature: undefined as number | undefined },
+    ];
+
+    const results = await Promise.all(
+      variants.map((v) =>
+        v.client
+          .chatCompletion({ model: v.model, messages, maxTokens: 1500, temperature: v.temperature })
+          .then((r) => [v.key, r.content] as const)
+          .catch((e) => [v.key, `ERROR: ${e instanceof Error ? e.message : String(e)}`] as const)
+      )
+    );
+
+    return c.json({ data: Object.fromEntries(results) });
+  } catch (error) {
+    console.error('insights-ab error:', error);
+    return c.json({ error: 'Failed to generate A/B insights' }, 500);
+  }
+});
+```
+
+> The route is on the same `app` that `apps/web/src/api/internal/index.ts` already mounts — no new mount needed. Confirm `AIService` is already imported in this file (it is — used for the existing summary route).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/api/internal/insights.ts
+git commit -m "feat(insights): add throwaway A/B debug route for model comparison"
+```
+
+---
+
+### Task 8: Slot the hand-authored few-shot examples ⚠️ GATED on the worksheet
+
+**Files:**
+- Modify: `packages/services/ai/src/prompts/user-insights-summary.ts` (`FEW_SHOT_EXAMPLES`)
+- Test: `apps/web/src/__tests__/services/ai.test.ts` (extend the prompt `describe`)
+
+**Interfaces:**
+- Consumes: the owner's 2–3 gold-standard summaries from the worksheet.
+- Produces: `FEW_SHOT_EXAMPLES` populated with **one full input→output pair** (one real week's data trimmed to production shape — top-5 artists with familiar/new flags, top-5 albums, recent tracks, 20 historical, `Total plays this week: N` = sum of the top-5 — then the owner's gold summary) **plus two voice-only summaries**.
+
+> **Do not start until the owner has written the examples.** The only human-gated task.
+
+- [ ] **Step 1: Write the failing test (extend the warmer-voice describe)**
+
+```typescript
+it('embeds the hand-authored gold examples', () => {
+  const user = buildUserInsightsMessages(insightsSample)[1].content;
+  // Substitute exact distinctive phrases the owner wrote:
+  expect(user).toContain('<distinctive phrase from gold example 1>');
+  expect(user).toContain('<distinctive phrase from gold example 2>');
+  expect(user).not.toContain('[PLACEHOLDER');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @listentomore/web exec vitest run src/__tests__/services/ai.test.ts -t "embeds the hand-authored"`
+Expected: FAIL — placeholder still present.
+
+- [ ] **Step 3: Fill `FEW_SHOT_EXAMPLES`**
+
+Replace the placeholder with the hybrid block: the paired example's input block mirrors the production `ListeningData` shape (top-5 artists with `(familiar)`/`(new for them)` flags, top-5 albums, recent tracks, the 20-artist rotation, `Total plays this week: N`), then the owner's gold summary, then two more gold summaries under a "more in the right voice" header. Pick a distinctive week (new-obsession or jazz-rabbit-hole) for the pair.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `pnpm --filter @listentomore/web test && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Owner verification (manual)**
+
+With the real `ANTHROPIC_API_KEY` set, run `pnpm dev` and hit `GET /api/internal/insights-ab?username=bordesak` (logged in as the owner) on 3–4 real weeks. Confirm the `sonnet46` output reads warm, reacts to the music with an opinion, uses no "not X / less-like-X-more-like-Y", stays ≤ 3 em dashes. Compare against `gpt54` and `opus48`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/services/ai/src/prompts/user-insights-summary.ts apps/web/src/__tests__/services/ai.test.ts
+git commit -m "feat(insights): slot hand-authored few-shot examples into the prompt"
+```
+
+---
+
+## Post-implementation cleanup (after the model decision)
+
+- Once a model is chosen and verified, **delete the A/B route** (`/insights-ab` handler) — it's scaffolding.
+- If GPT-5.4 wins, the revert is one line: `userInsightsSummary.provider` → `'openai'`, `model` → `'gpt-5.4'`, restore `temperature`/`verbosity`. The `AnthropicClient` stays, dormant.
+
+## Self-Review
+
+**Spec coverage:** Persona rewrite → T5 ✓. Cut "Do NOT" wall to two bans → T5 ✓. Hybrid few-shot → T8 (gated) ✓. Drop atmosphere framing → T5 ✓. Config flip → T6 ✓. Cache-bust across get/set/delete → T5 ✓. `AnthropicClient` → T2 ✓. `AI_PROVIDERS`/`RATE_LIMITS`/rate-limiter fix → T1 ✓. Metadata widening → T2 ✓. Service wiring + switch + 3 sites + 2 Env types + `.dev.vars` → T3 ✓. A/B route → T7 ✓. Acceptance verification → T8 Step 5 ✓.
+
+**Placeholder scan:** Only intentional placeholder is `FEW_SHOT_EXAMPLES` (T5 ships a marked stub; T8 fills from the human artifact — the one gated task). No "TBD"/"add error handling"/"similar to Task N".
+
+**Type consistency:** `AIProvider` widened (T1) before `RATE_LIMITS[provider]` / `new AIRateLimiter(_, 'anthropic')`. `AIResponseMetadata.provider`/`api` widened (T2) before the client sets `'anthropic'`/`'messages'`. Every symbol a web test imports from `@listentomore/ai` is re-exported from the barrel in the same task that introduces it (`AnthropicClient` T2; `buildUserInsightsMessages` T4; `USER_INSIGHTS_PROMPT_VERSION` T5). `anthropicApiKey` added to `AIServiceConfig` (T3) before all three call sites pass it.
+
+**Test-infra check:** all tests live in `apps/web/src/__tests__/services/ai.test.ts` (the AI package has no runner); imports from `@listentomore/ai`/`@listentomore/config`/`../utils/mocks`; `setupFetchMock`/`createMockKV` per the existing file's pattern; run via the web filter.

--- a/docs/superpowers/specs/2026-06-19-insights-warmer-voice-design.md
+++ b/docs/superpowers/specs/2026-06-19-insights-warmer-voice-design.md
@@ -1,0 +1,113 @@
+# Design: Warmer `/insights` summary voice (few-shot + Claude)
+
+**Issue:** [#32](https://github.com/rianvdm/listentomore/issues/32)
+**Date:** 2026-06-19
+**Status:** Design — awaiting review
+
+## Problem
+
+The "Your Week in Music" summary on `/insights` reads cold and AI-generated. The prompt is already saturated with anti-AI-pattern prohibitions, so adding more "Do NOT" rules doesn't help — the model evades them and the core stance stays clinical. Two structural causes (not rule gaps):
+
+1. **Stance:** the persona is "an observer who finds the pattern you missed" — an analyst profiling a data-subject, which is inherently cold. Every sentence is *about the listener*, none reacts to the *music*.
+2. **Method:** warmth is pursued through a long negative-instruction list, which produces voiceless, hedged prose. Voice is taught by example, not prohibition.
+
+Also: `userInsightsSummary` sets `temperature: 0.7`, but it routes through GPT-5.4 on OpenAI's Responses API, where temperature is effectively pinned to 1 (confirmed by the config's own note at `packages/config/src/ai.ts:60-63`). The warmth dial we think we have is inert.
+
+## Approach (committed in the issue)
+
+**A. Change the stance + teach voice by example.** Rewrite the system persona to a friend reacting to the week, *allowed to have opinions about the music itself*. Replace most of the "Do NOT" list with hand-authored gold-standard few-shot examples in the owner's voice. Keep only the two structural bans the current prompt misses. Drop the atmosphere-seeding "temperature" framing.
+
+**C. Add Claude (Anthropic) as a provider and A/B against GPT-5.4.** Claude writes warmer and follows voice exemplars more faithfully; the rest of the stack is Claude. Default this task to `claude-sonnet-4-6`; test `claude-opus-4-8` as a quality ceiling.
+
+A and C ship together. C has no dependency on the examples, so it can be built in parallel while the examples are authored.
+
+## Decisions
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Few-shot form | **Hybrid:** 1 full input→output pair + 2 voice-only exemplars | The pair grounds the model in this data shape (using the familiar/new flags, naming real tracks); the 2 voice-only reinforce register cheaply. |
+| A/B mechanic | **Internal debug route** `GET /api/internal/insights-ab?username=X` | Runs all three provider/model configs on the same week's data, cache-bypassed, returns them side by side. Removable scaffolding. |
+| "Fallback to GPT-5.4" | **Config-switchable only** | Reverting = flip `userInsightsSummary.provider` back to `'openai'`. No runtime try/catch in v1. |
+| Default model | `claude-sonnet-4-6` | Rian's explicit cost/latency call for a daily-cached weekly summary; `claude-opus-4-8` is the ceiling test in the A/B route. |
+| Anthropic transport | **Raw `fetch` mirroring `OpenAIClient`** (recommended) | The AI layer is deliberately SDK-free (`OpenAIClient` uses raw `fetchWithTimeout`, no `openai` dep). Mirroring it avoids a new dep and matches house style. ⚠️ The `claude-api` skill's default is the official `@anthropic-ai/sdk`; flagged for review — if preferred, swap the adapter internals to the SDK (works in Workers). |
+
+## Architecture
+
+### Part A — Prompt rewrite (`packages/services/ai/src/prompts/user-insights-summary.ts`)
+
+1. **Extract a pure message builder** `buildUserInsightsMessages(listeningData): ChatMessage[]` (exported), returning `[systemMessage, userMessage]` (plus interleaved few-shot example turns). Both the production generate function and the A/B route consume it. This makes the prompt unit-testable and keeps one source of truth.
+2. **New system persona:** a friend who pays attention to what someone listens to and *reacts to the music* — allowed to have opinions about songs and records, not just profile the listener.
+3. **Cut the "Do NOT" wall** down to the two structural bans the current prompt misses:
+   - the "not X / less-like-X-more-like-Y" construction **anywhere** (current prompt only bans it as an *opening*),
+   - an **em-dash cap** (≤ 3 per summary).
+4. **Few-shot (hybrid):** one full `[example week data] → [gold summary]` pair as prior turns, then 2 standalone gold summaries presented as voice references, then "Now here is THIS week: …". All summaries are hand-authored by the owner. The paired example's *input block* is trimmed to the **production `ListeningData` shape** (top-5 artists with familiar/new flags, top-5 albums, ~30 recent tracks, 20 historical artists, `weeklyPlayCount`).
+5. **Drop** the "the week has a clear temperature" line and other atmosphere-seeding language.
+6. **Config flip** (`packages/config/src/ai.ts`, `userInsightsSummary`): `provider: 'anthropic'`, `model: 'claude-sonnet-4-6'`, `temperature: 0.8` (now a *live* dial on Sonnet — unlike GPT-5.4). Keep `maxTokens: 1500`, `cacheTtlDays: 1`. Remove `verbosity` (OpenAI-only; ignored by the Anthropic adapter anyway).
+7. **Cache-bust:** add a prompt-version token to the cache key so old cold summaries don't linger. The key is built in `AICache.makeKey` as `ai:<task>:<params>`; add a version param (e.g. `'v2'`) to the `cache.get`/`cache.set` calls inside `generateUserInsightsSummary` **and** to the `ai.cache.delete('userInsightsSummary', username)` call at `apps/web/src/api/internal/insights.ts:119`.
+
+### Part C — Anthropic provider
+
+1. **`AnthropicClient implements ChatClient`** (`packages/services/ai/src/anthropic.ts`), mirroring `OpenAIClient`:
+   - constructor `(apiKey, rateLimiter?)`; `chatCompletion(options)` → `POST https://api.anthropic.com/v1/messages` via `fetchWithTimeout` (`timeout: 'slow'`).
+   - **Extract the system message** from `options.messages` to the top-level `system` param; pass remaining user/assistant turns as `messages`.
+   - `maxTokens` → `max_tokens` (required by Anthropic).
+   - **Omit `temperature` for opus-tier models** (`claude-opus-4-8`, `claude-opus-4-7`, `claude-fable-5`) — those reject sampling params with a 400. Pass it for `claude-sonnet-4-6`/Haiku. (Guard via a small `MODELS_WITHOUT_TEMPERATURE` set or a `startsWith('claude-opus-4-7'|'-4-8')` check.)
+   - Ignore OpenAI-only options (`reasoning`, `verbosity`, `webSearch`).
+   - Headers: `x-api-key`, `anthropic-version: 2023-06-01`, `content-type: application/json`.
+   - Parse `content[0].text`; build `AIResponseMetadata` with `provider: 'anthropic'`, `model` from the response, `api: 'messages'`, `usage` from `usage.input_tokens`/`output_tokens`.
+2. **Config** (`packages/config/src/ai.ts`):
+   - `AI_PROVIDERS.anthropic = { baseUrl: 'https://api.anthropic.com/v1', defaultModel: 'claude-sonnet-4-6' }`. Adding this makes `'anthropic'` a valid `AIProvider` automatically (`AIProvider = keyof typeof AI_PROVIDERS`).
+   - `RATE_LIMITS.anthropic = { requestsPerMinute: 50, tokensPerMinute: 40000 }` (conservative client-side throttle for a low-volume, daily-cached call; well under any real Anthropic tier — tune later if needed).
+3. **Types** (`packages/services/ai/src/types.ts`): widen `AIResponseMetadata.provider` from the literal `'openai'` to `'openai' | 'anthropic'`, and add `'messages'` to the `api` union.
+4. **Service wiring** (`packages/services/ai/src/index.ts`):
+   - `AIServiceConfig` gains `anthropicApiKey: string`.
+   - construct `this.anthropic = new AnthropicClient(config.anthropicApiKey, new AIRateLimiter(config.cache, 'anthropic'))` (the `AIRateLimiter` is already provider-parameterized — `new AIRateLimiter(cache, 'openai')` at `index.ts:82`).
+   - `getClientForTask(task)` switches on `getTaskConfig(task).provider` → returns `this.anthropic` or `this.openai`.
+   - expose `this.anthropic` publicly (like `this.openai`) so the A/B route can reach it.
+5. **Secret/binding:** add `ANTHROPIC_API_KEY` to `apps/web/.dev.vars` and as a `wrangler secret` in prod; thread it into `AIServiceConfig` wherever the `AIService` is constructed (the binding/middleware that builds `c.get('ai')`).
+
+### A/B debug route (`apps/web/src/api/internal/insights.ts`, new handler)
+
+`GET /api/internal/insights-ab?username=X`, gated by `requireSessionAuth` + reusing `getUserWithInsightsAccess` (owner/privacy check). Reuses the exact `ListeningData` assembly from `/user-insights-summary` (`insights.ts:124-156`), calls `buildUserInsightsMessages(data)` once, then runs the messages through three `(client, model)` combos **cache-bypassed**:
+
+- `{ client: ai.openai, model: 'gpt-5.4' }`
+- `{ client: ai.anthropic, model: 'claude-sonnet-4-6' }`
+- `{ client: ai.anthropic, model: 'claude-opus-4-8' }`
+
+Returns `{ gpt54, sonnet46, opus48 }`. Throwaway scaffolding — delete once the comparison is done. (Bypassing cache = calling `client.chatCompletion({ model, messages, maxTokens: 1500, temperature })` directly, not the cached `generateUserInsightsSummary` helper.)
+
+## Gotchas captured
+
+- **Opus rejects `temperature`** (400) — the adapter must omit it for opus-tier; live on Sonnet. This would have surfaced at A/B time on the opus path.
+- **`weeklyPlayCount` is the sum of the top-5 artists' playcounts** (`insights.ts:133`), not the true weekly total — match this when trimming the paired example's input.
+- **Historical = `getTopArtists('6month', 20)`** (20, not more); the paired example's rotation list is trimmed to 20.
+- **System-message extraction:** Anthropic takes `system` as a top-level param; the adapter pulls it out of the `messages` array (mirror of `OpenAIClient.convertMessagesToResponsesFormat`).
+- **Cache key versioning** touches three call sites (get, set, delete) — miss one and stale summaries leak or refresh breaks.
+
+## Testing
+
+- **`buildUserInsightsMessages`** (pure, unit): asserts the new persona is present, the two structural bans appear, the few-shot example summaries are embedded, and the atmosphere-seeding lines are gone. Data-driven: feeds a sample `ListeningData` and checks the familiar/new flags render.
+- **`AnthropicClient.chatCompletion`** (unit, mocked fetch): system message extracted to top-level `system`; `maxTokens`→`max_tokens`; **temperature omitted for `claude-opus-4-8`, present for `claude-sonnet-4-6`**; metadata `provider: 'anthropic'`; error path throws on non-200.
+- **`getClientForTask`**: returns the anthropic client for a task configured `provider: 'anthropic'`, openai otherwise.
+- **Metadata type:** `provider: 'anthropic'` type-checks (widened union).
+- A/B route: light smoke (auth gate + shape), not a full integration test.
+
+Follow the repo's Vitest conventions (`globals: true`, tests in `src/__tests__/` mirroring source, mock `globalThis.fetch`).
+
+## Acceptance criteria (from the issue) → how met
+
+- Reads like a friend reacting to the music, ≥1 opinion about a song/album → persona rewrite + few-shot + an opinion in every gold example.
+- No "not X — but Y" / "less like X, more like Y" → explicit anywhere-ban + examples that never use it.
+- ≤ 3 em dashes → explicit cap + examples that obey it.
+- Voice driven by hand-authored few-shot, not a prohibition list → the "Do NOT" wall is cut to two bans; voice comes from examples.
+- Runs on Claude with a clean fallback to GPT-5.4 → `provider: 'anthropic'` default; one-line config revert.
+- Side-by-side on 3–4 real weeks before shipping → the internal A/B route.
+
+## Out of scope
+
+- The recommendations prompt (`user-insights-recommendations.ts`) — structured output, separate concern; follow-up if wanted.
+- Runtime try/catch provider fallback — config-switchable only in v1.
+
+## Open dependency
+
+The few-shot examples must be **hand-authored by the owner** (the model can't invent the voice). Worksheet with the 4 real weeks in prompt-input shape is at `~/git/product-ai/05-personal/side-projects/listentomore/2026-06-19-insights-voice-examples-worksheet.md`. Build can proceed to ~95% (all of C, plus A's structure with placeholder example slots) before the real examples are slotted in.

--- a/packages/config/src/ai.ts
+++ b/packages/config/src/ai.ts
@@ -138,12 +138,11 @@ export const AI_TASKS = {
   },
 
   userInsightsSummary: {
-    provider: 'openai',
-    model: 'gpt-5.4',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
     maxTokens: 1500,
-    temperature: 0.7,
+    temperature: 0.8,
     cacheTtlDays: 1,
-    verbosity: 'medium',
   },
 
   userInsightsRecommendations: {

--- a/packages/config/src/ai.ts
+++ b/packages/config/src/ai.ts
@@ -8,6 +8,10 @@ export const AI_PROVIDERS = {
     baseUrl: 'https://api.openai.com/v1',
     defaultModel: 'gpt-5-mini',
   },
+  anthropic: {
+    baseUrl: 'https://api.anthropic.com/v1',
+    defaultModel: 'claude-sonnet-4-6',
+  },
 } as const;
 
 export type AIProvider = keyof typeof AI_PROVIDERS;
@@ -168,6 +172,10 @@ export const RATE_LIMITS = {
   openai: {
     requestsPerMinute: 90,
     tokensPerMinute: 90000,
+  },
+  anthropic: {
+    requestsPerMinute: 50,
+    tokensPerMinute: 40000,
   },
   spotify: {
     requestsPerMinute: 150, // (Spotify allows ~180)

--- a/packages/config/src/ai.ts
+++ b/packages/config/src/ai.ts
@@ -139,8 +139,11 @@ export const AI_TASKS = {
 
   userInsightsSummary: {
     provider: 'anthropic',
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     maxTokens: 1500,
+    // temperature is inert on claude-sonnet-5 (rejected with a 400; the
+    // AnthropicClient omits it for this model) — kept only to satisfy the
+    // AITaskConfig shape. Warmth comes from the persona + few-shot examples.
     temperature: 0.8,
     cacheTtlDays: 1,
   },

--- a/packages/services/ai/src/anthropic.ts
+++ b/packages/services/ai/src/anthropic.ts
@@ -1,0 +1,106 @@
+// ABOUTME: Anthropic (Claude) API client mirroring the OpenAIClient shape.
+// ABOUTME: Calls POST /v1/messages via raw fetch; no SDK dependency.
+
+import { AI_PROVIDERS } from '@listentomore/config';
+import { fetchWithTimeout } from '@listentomore/shared';
+import type {
+  ChatClient,
+  ChatCompletionOptions,
+  ChatCompletionResponse,
+  AIResponseMetadata,
+} from './types';
+import type { AIRateLimiter } from './rate-limit';
+
+const ANTHROPIC_VERSION = '2023-06-01';
+
+// Opus-tier (4.7+) and Fable 5 reject sampling params with a 400.
+const MODELS_WITHOUT_TEMPERATURE = [
+  'claude-opus-4-8',
+  'claude-opus-4-7',
+  'claude-fable-5',
+];
+
+export class AnthropicClient implements ChatClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private rateLimiter: AIRateLimiter | null;
+
+  constructor(apiKey: string, rateLimiter?: AIRateLimiter) {
+    this.apiKey = apiKey;
+    this.baseUrl = AI_PROVIDERS.anthropic.baseUrl;
+    this.rateLimiter = rateLimiter ?? null;
+  }
+
+  async chatCompletion(
+    options: ChatCompletionOptions
+  ): Promise<ChatCompletionResponse> {
+    if (this.rateLimiter) {
+      await this.rateLimiter.acquire();
+    }
+
+    // Anthropic takes the system prompt as a top-level param, not a message.
+    const systemMessage = options.messages.find((m) => m.role === 'system');
+    const conversation = options.messages.filter((m) => m.role !== 'system');
+
+    const body: Record<string, unknown> = {
+      model: options.model,
+      max_tokens: options.maxTokens ?? 1500,
+      messages: conversation.map((m) => ({ role: m.role, content: m.content })),
+    };
+    if (systemMessage) {
+      body.system = systemMessage.content;
+    }
+    // Only send temperature where the model supports it.
+    if (
+      options.temperature !== undefined &&
+      !MODELS_WITHOUT_TEMPERATURE.some((m) => options.model.startsWith(m))
+    ) {
+      body.temperature = options.temperature;
+    }
+
+    const response = await fetchWithTimeout(`${this.baseUrl}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify(body),
+      timeout: 'slow', // 30 seconds for AI
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error(`[Anthropic] API error: ${response.status} - ${errorBody}`);
+      throw new Error(`Anthropic API error: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      model: string;
+      content: Array<{ type: string; text?: string }>;
+      usage?: { input_tokens?: number; output_tokens?: number };
+    };
+
+    const content = data.content
+      .filter((b) => b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text)
+      .join('');
+
+    const metadata: AIResponseMetadata = {
+      provider: 'anthropic',
+      model: data.model,
+      api: 'messages',
+      usage: data.usage
+        ? {
+            inputTokens: data.usage.input_tokens ?? null,
+            outputTokens: data.usage.output_tokens ?? null,
+            totalTokens:
+              (data.usage.input_tokens ?? 0) + (data.usage.output_tokens ?? 0) ||
+              null,
+          }
+        : undefined,
+    };
+
+    return { content, metadata };
+  }
+}

--- a/packages/services/ai/src/anthropic.ts
+++ b/packages/services/ai/src/anthropic.ts
@@ -13,11 +13,14 @@ import type { AIRateLimiter } from './rate-limit';
 
 const ANTHROPIC_VERSION = '2023-06-01';
 
-// Opus-tier (4.7+) and Fable 5 reject sampling params with a 400.
+// Newer-generation models reject sampling params (temperature/top_p/top_k)
+// with a 400: opus-tier (4.7+), Fable 5, and Sonnet 5. Verified live for
+// claude-sonnet-5 on 2026-07-01 ("`temperature` is deprecated for this model").
 const MODELS_WITHOUT_TEMPERATURE = [
   'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-fable-5',
+  'claude-sonnet-5',
 ];
 
 export class AnthropicClient implements ChatClient {

--- a/packages/services/ai/src/index.ts
+++ b/packages/services/ai/src/index.ts
@@ -18,6 +18,7 @@ export type {
 
 // Re-export clients and cache for direct use
 export { OpenAIClient } from './openai';
+export { AnthropicClient } from './anthropic';
 export type {
   ChatCompletionOptions,
   ChatCompletionResponse,

--- a/packages/services/ai/src/index.ts
+++ b/packages/services/ai/src/index.ts
@@ -1,7 +1,8 @@
 // AI service - consolidated AI functionality for text and image generation
 
-import type { AITask } from '@listentomore/config';
+import { getTaskConfig, type AITask } from '@listentomore/config';
 import { OpenAIClient } from './openai';
+import { AnthropicClient } from './anthropic';
 import { AICache } from './cache';
 import { AIRateLimiter } from './rate-limit';
 import type { ChatClient } from './types';
@@ -66,6 +67,7 @@ export {
 
 export interface AIServiceConfig {
   openaiApiKey: string;
+  anthropicApiKey: string;
   cache: KVNamespace;
 }
 
@@ -74,25 +76,33 @@ export interface AIServiceConfig {
  */
 export class AIService {
   public readonly openai: OpenAIClient;
+  public readonly anthropic: AnthropicClient;
   public readonly cache: AICache;
   public readonly kv: KVNamespace;
   public readonly openaiRateLimiter: AIRateLimiter;
+  public readonly anthropicRateLimiter: AIRateLimiter;
 
   constructor(config: AIServiceConfig) {
-    // Create distributed rate limiter for OpenAI
+    // Create distributed rate limiters per provider
     this.openaiRateLimiter = new AIRateLimiter(config.cache, 'openai');
+    this.anthropicRateLimiter = new AIRateLimiter(config.cache, 'anthropic');
 
-    // Create client with rate limiter
+    // Create clients with rate limiters
     this.openai = new OpenAIClient(config.openaiApiKey, this.openaiRateLimiter);
+    this.anthropic = new AnthropicClient(
+      config.anthropicApiKey,
+      this.anthropicRateLimiter
+    );
     this.cache = new AICache(config.cache);
     this.kv = config.cache;
   }
 
   /**
-   * Get the appropriate client for a task based on config.
+   * Get the appropriate client for a task based on config.provider.
    */
-  getClientForTask(_task: AITask): ChatClient {
-    return this.openai;
+  getClientForTask(task: AITask): ChatClient {
+    const { provider } = getTaskConfig(task);
+    return provider === 'anthropic' ? this.anthropic : this.openai;
   }
 
   // Convenience methods that use the appropriate client based on config

--- a/packages/services/ai/src/index.ts
+++ b/packages/services/ai/src/index.ts
@@ -49,6 +49,7 @@ export {
   generateListenAIResponse,
   generateAlbumRecommendations,
   generateUserInsightsSummary,
+  buildUserInsightsMessages,
   generateUserInsightsRecommendations,
   type ArtistSummaryResult,
   type AlbumDetailResult,

--- a/packages/services/ai/src/index.ts
+++ b/packages/services/ai/src/index.ts
@@ -50,6 +50,7 @@ export {
   generateAlbumRecommendations,
   generateUserInsightsSummary,
   buildUserInsightsMessages,
+  USER_INSIGHTS_PROMPT_VERSION,
   generateUserInsightsRecommendations,
   type ArtistSummaryResult,
   type AlbumDetailResult,

--- a/packages/services/ai/src/prompts/index.ts
+++ b/packages/services/ai/src/prompts/index.ts
@@ -38,6 +38,7 @@ export {
 export {
   generateUserInsightsSummary,
   buildUserInsightsMessages,
+  USER_INSIGHTS_PROMPT_VERSION,
   type UserInsightsSummaryResult,
   type ListeningData as InsightsListeningData,
 } from './user-insights-summary';

--- a/packages/services/ai/src/prompts/index.ts
+++ b/packages/services/ai/src/prompts/index.ts
@@ -37,6 +37,7 @@ export {
 
 export {
   generateUserInsightsSummary,
+  buildUserInsightsMessages,
   type UserInsightsSummaryResult,
   type ListeningData as InsightsListeningData,
 } from './user-insights-summary';

--- a/packages/services/ai/src/prompts/user-insights-summary.ts
+++ b/packages/services/ai/src/prompts/user-insights-summary.ts
@@ -23,12 +23,70 @@ export const USER_INSIGHTS_PROMPT_VERSION = 'v2';
 const SYSTEM_PROMPT =
   "You're a friend who pays attention to what people listen to. When someone shows you their week, you react to the music itself — you have opinions about records and songs, the ones you love, the ones that surprised you, the stuff you'd text them about. You know their usual rotation and what's new for them. You're not analyzing them; you're talking about the music with someone whose taste you know.";
 
-// Hand-authored gold-standard examples in the owner's voice. Filled in Task 8
-// from the worksheet. Until then this is a single neutral placeholder so the
-// structure compiles and the bans/voice are exercised by tests.
-const FEW_SHOT_EXAMPLES = `Here are a couple of summaries in the right voice (one with the data it came from, then two on their own):
+// Hand-authored gold-standard examples in the owner's voice. The first shows
+// the week's input data it was written from (so the model learns to read the
+// shape); the next two are just the writing.
+const FEW_SHOT_EXAMPLES = `Here are a few summaries in the right voice. The first one shows the week's data it came from; the next two are just the writing.
 
-[PLACEHOLDER — replace with the owner's hand-authored examples in Task 8]`;
+Here's a week:
+
+Total plays this week: 118
+
+Top artists this week:
+- Boards of Canada: 50 plays (familiar)
+- Nils Frahm: 24 plays (familiar)
+- Jars of Clay: 17 plays (familiar)
+- Chief Xian aTunde Adjuah: 14 plays (new for them)
+- Pink Floyd: 13 plays (familiar)
+
+Top albums this week:
+- Tomorrow's Harvest by Boards of Canada: 50 plays
+- All Melody by Nils Frahm: 18 plays
+- Bark Out Thunder Roar Out Lightning by Chief Xian aTunde Adjuah: 14 plays
+- Who We Are Instead by Jars of Clay: 12 plays
+- The Dark Side of the Moon by Pink Floyd: 11 plays
+
+Recent tracks (most recent first):
+- Deep Time — Boards of Canada
+- The Word Becomes Flesh — Boards of Canada
+- Reach for the Dead — Boards of Canada
+- Blue Bossa — Joe Henderson
+- Footprints — Wayne Shorter
+- Mercy, Mercy, Mercy — Cannonball Adderley
+- Idle Moments — Grant Green
+- Why Was I Born — Kenny Burrell & John Coltrane
+- Four on Six — Wes Montgomery
+- Possession — Chief Xian aTunde Adjuah
+- Says — Nils Frahm
+- Sugar for the Pill — Slowdive
+- Time — Pink Floyd
+- Everything in Its Right Place — Radiohead
+
+Their rotation over the past 6 months: Boards of Canada, Nils Frahm, Death Cab for Cutie, Radiohead, Slowdive, Pink Floyd, Jars of Clay, Deserta, Celer, Stars of the Lid, Ólafur Arnalds, Sigur Rós, Peter Gabriel, Genesis, Khruangbin, Aurenza, Somniscape, Röyksopp
+
+What you'd write:
+
+Two things happened this week and they couldn't be further apart. One: a 50-play Boards of Canada immersion — Deep Time and The Word Becomes Flesh on repeat, the kind of run where you stop noticing the album changed. Two: a mid-century jazz rabbit hole, completely out of left field.
+
+The jazz dig is the story. Joe Henderson, Wayne Shorter, Cannonball Adderley, Grant Green, Kenny Burrell and Coltrane, Wes Montgomery, all in one week, none of it anywhere near your usual rotation. Good instincts, too — Joe Henderson is exactly where you start. Chief Xian aTunde Adjuah (new for you) at 14 plays says it stuck. When you fall into something, you fall all the way in.
+
+Everything else was business as usual: Nils Frahm, Slowdive, Pink Floyd, Radiohead. But this week belonged to those two obsessions running side by side.
+
+Here's another week, just the summary:
+
+Siiga came out of nowhere and took the top spot in a week — Nostalgia Burns at 39 plays, and it slots right into the ambient pocket you already live in next to Celer, Nils Frahm, and Deserta. The Capri remaster got the full front-to-back treatment too, so a lot of this week was pressing play and letting a record run.
+
+Around the ambient stuff, the familiar names held up. You went back to In Rainbows and ran the whole thing. Still the one, no argument. I Built You A Tower stayed in heavy rotation too, and the Raveonettes binge (Pe'ahi II and Lust Lust Lust back to back) was the one loud stretch this week.
+
+The Police live album is the curveball. Certifiable at 21 plays is a lot of stage banter and crowd noise for someone who mostly listens to drone. But Every Breath You Take live still does the job.
+
+And one more:
+
+This was an I Built You A Tower week, full stop. You wore the whole record down to the grain — Envy the Birds, Full of Stars, Pep Talk, Stone Over Water all sitting around three plays each. When a Death Cab record clicks for you, it clicks.
+
+Underneath it, the usual ambient names were all there: Nils Frahm at 31, plus Ólafur Arnalds, Stars of the Lid, and Sigur Rós. Seasurfer's Stay was the one new thing that stuck.
+
+Then the weird ones, which are the fun part. Evanescence (Beautiful Lie, How Do I Heal), Michael Jackson, and Chris de Burgh all showed up the same week as Stars of the Lid. No notes. That's a healthy week.`;
 
 /**
  * Build the chat messages for the weekly insights summary.

--- a/packages/services/ai/src/prompts/user-insights-summary.ts
+++ b/packages/services/ai/src/prompts/user-insights-summary.ts
@@ -17,8 +17,18 @@ export interface ListeningData {
   historicalArtists: Array<{ name: string }>;
 }
 
+/** Bump when the prompt changes so cached cold summaries don't linger. */
+export const USER_INSIGHTS_PROMPT_VERSION = 'v2';
+
 const SYSTEM_PROMPT =
-  "You're a friend who pays attention to what people listen to. When someone shares their week, you find the one thing that's actually interesting about it — not the obvious summary, but the pattern they might not have noticed themselves. You know their usual rotation and what's new for them. You write like a person, not a report: one sharp observation, specific and earned.";
+  "You're a friend who pays attention to what people listen to. When someone shows you their week, you react to the music itself — you have opinions about records and songs, the ones you love, the ones that surprised you, the stuff you'd text them about. You know their usual rotation and what's new for them. You're not analyzing them; you're talking about the music with someone whose taste you know.";
+
+// Hand-authored gold-standard examples in the owner's voice. Filled in Task 8
+// from the worksheet. Until then this is a single neutral placeholder so the
+// structure compiles and the bans/voice are exercised by tests.
+const FEW_SHOT_EXAMPLES = `Here are a couple of summaries in the right voice (one with the data it came from, then two on their own):
+
+[PLACEHOLDER — replace with the owner's hand-authored examples in Task 8]`;
 
 /**
  * Build the chat messages for the weekly insights summary.
@@ -62,19 +72,14 @@ ${recentTracksSlice.map((t) => `- ${t.name} — ${t.artist}`).join('\n') || '- (
 
 Their rotation over the past 6 months: ${historicalArtists.map((a) => a.name).join(', ') || 'none on record'}
 
-Things worth looking for — pick ONE, don't try to cover everything:
-- An obsession: one artist or album eating the week
-- A rabbit hole: a thread from one artist, scene, or era to another
-- A return: coming back to something they hadn't played in a while
-- A break: stepping outside their usual rotation
-- A mood: the week has a clear temperature, even across different artists
-- A contrast: the gap between what they're usually into and what this week actually was
+${FEW_SHOT_EXAMPLES}
 
-Write 2 to 3 short paragraphs in second person. Give the observation room to breathe: set it up, show the evidence in the tracks and albums, land the point. Name specific artists, albums, or tracks. Use the familiar/new flags.
+Now write theirs. 2 to 3 short paragraphs, second person. React to the music with at least one real opinion about a song or record, not a description of the listener. Name specific artists, albums, or tracks, and use the familiar/new flags. If the week is mostly their usual rotation, say so plainly, then find the small thing still worth noting.
 
-Open with a direct observation — something concrete that's actually in their week. Do NOT open with a rhetorical hook ("The interesting thing is...", "What stands out is...", "Here's what's notable..."). Do NOT open with "Based on your listening" or "This week you listened to." Start in the scene, not above it.
-
-You can be a little writerly if the observation earns it, but no clichés, no recommendations. If the week is genuinely unremarkable — mostly their usual rotation without much variation — say that plainly, then find the small thing that's still worth noting.`;
+Hard rules:
+- Never use "not X — but Y", "it isn't X, it's Y", or "less like X, more like Y" anywhere. This is the move to avoid.
+- At most 3 em dashes in the whole thing.
+- No clichés, no recommendations, no mood/atmosphere adjectives standing in for an actual observation.`;
 
   return [
     { role: 'system', content: SYSTEM_PROMPT },
@@ -96,7 +101,8 @@ export async function generateUserInsightsSummary(
   // Check cache first
   const cached = await cache.get<UserInsightsSummaryResult>(
     'userInsightsSummary',
-    normalizedUsername
+    normalizedUsername,
+    USER_INSIGHTS_PROMPT_VERSION
   );
   if (cached) {
     return cached;
@@ -120,7 +126,7 @@ export async function generateUserInsightsSummary(
   };
 
   // Cache the result (without metadata)
-  await cache.set('userInsightsSummary', [normalizedUsername], {
+  await cache.set('userInsightsSummary', [normalizedUsername, USER_INSIGHTS_PROMPT_VERSION], {
     content: result.content,
   });
 

--- a/packages/services/ai/src/prompts/user-insights-summary.ts
+++ b/packages/services/ai/src/prompts/user-insights-summary.ts
@@ -1,7 +1,7 @@
 // User insights summary prompt - generates personalized listening analysis
 
 import { getTaskConfig } from '@listentomore/config';
-import type { ChatClient, AIResponseMetadata } from '../types';
+import type { ChatClient, ChatMessage, AIResponseMetadata } from '../types';
 import type { AICache } from '../cache';
 
 export interface UserInsightsSummaryResult {
@@ -17,31 +17,27 @@ export interface ListeningData {
   historicalArtists: Array<{ name: string }>;
 }
 
+const SYSTEM_PROMPT =
+  "You're a friend who pays attention to what people listen to. When someone shares their week, you find the one thing that's actually interesting about it — not the obvious summary, but the pattern they might not have noticed themselves. You know their usual rotation and what's new for them. You write like a person, not a report: one sharp observation, specific and earned.";
+
 /**
- * Generate a personalized summary of user's 7-day listening patterns
+ * Build the chat messages for the weekly insights summary.
+ * Pure — no cache, no client. Shared by generate + the A/B route.
  */
-export async function generateUserInsightsSummary(
-  username: string,
-  listeningData: ListeningData,
-  client: ChatClient,
-  cache: AICache
-): Promise<UserInsightsSummaryResult> {
-  const normalizedUsername = username.toLowerCase().trim();
+export function buildUserInsightsMessages(
+  listeningData: ListeningData
+): ChatMessage[] {
+  const {
+    topArtists,
+    topAlbums,
+    recentTracks,
+    weeklyPlayCount,
+    historicalArtists,
+  } = listeningData;
 
-  // Check cache first
-  const cached = await cache.get<UserInsightsSummaryResult>(
-    'userInsightsSummary',
-    normalizedUsername
+  const historicalNames = new Set(
+    historicalArtists.map((a) => a.name.toLowerCase())
   );
-  if (cached) {
-    return cached;
-  }
-
-  const config = getTaskConfig('userInsightsSummary');
-
-  const { topArtists, topAlbums, recentTracks, weeklyPlayCount, historicalArtists } = listeningData;
-
-  const historicalNames = new Set(historicalArtists.map((a) => a.name.toLowerCase()));
   const annotatedArtists = topArtists.map((a) => ({
     ...a,
     isRegular: historicalNames.has(a.name.toLowerCase()),
@@ -51,7 +47,7 @@ export async function generateUserInsightsSummary(
   const topAlbumsSlice = topAlbums.slice(0, 5);
   const recentTracksSlice = recentTracks.slice(0, 30);
 
-  const prompt = `Here's someone's listening from the past week. Find the one thing about it that's genuinely interesting — the pattern a friend who knows their taste would call out, not a recap.
+  const userPrompt = `Here's someone's listening from the past week. Find the one thing about it that's genuinely interesting — the pattern a friend who knows their taste would call out, not a recap.
 
 Total plays this week: ${weeklyPlayCount}
 
@@ -80,16 +76,38 @@ Open with a direct observation — something concrete that's actually in their w
 
 You can be a little writerly if the observation earns it, but no clichés, no recommendations. If the week is genuinely unremarkable — mostly their usual rotation without much variation — say that plainly, then find the small thing that's still worth noting.`;
 
+  return [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: userPrompt },
+  ];
+}
+
+/**
+ * Generate a personalized summary of user's 7-day listening patterns
+ */
+export async function generateUserInsightsSummary(
+  username: string,
+  listeningData: ListeningData,
+  client: ChatClient,
+  cache: AICache
+): Promise<UserInsightsSummaryResult> {
+  const normalizedUsername = username.toLowerCase().trim();
+
+  // Check cache first
+  const cached = await cache.get<UserInsightsSummaryResult>(
+    'userInsightsSummary',
+    normalizedUsername
+  );
+  if (cached) {
+    return cached;
+  }
+
+  const config = getTaskConfig('userInsightsSummary');
+  const messages = buildUserInsightsMessages(listeningData);
+
   const response = await client.chatCompletion({
     model: config.model,
-    messages: [
-      {
-        role: 'system',
-        content:
-          "You're a friend who pays attention to what people listen to. When someone shares their week, you find the one thing that's actually interesting about it — not the obvious summary, but the pattern they might not have noticed themselves. You know their usual rotation and what's new for them. You write like a person, not a report: one sharp observation, specific and earned.",
-      },
-      { role: 'user', content: prompt },
-    ],
+    messages,
     maxTokens: config.maxTokens,
     temperature: config.temperature,
     reasoning: config.reasoning,

--- a/packages/services/ai/src/rate-limit.ts
+++ b/packages/services/ai/src/rate-limit.ts
@@ -9,7 +9,7 @@ export interface AIRateLimitState {
   retryAfter?: number;
 }
 
-export type AIProvider = 'openai';
+export type AIProvider = 'openai' | 'anthropic';
 
 export class AIRateLimiter {
   private readonly cacheKey: string;
@@ -21,7 +21,7 @@ export class AIRateLimiter {
     private provider: AIProvider
   ) {
     this.cacheKey = `ai:ratelimit:${provider}`;
-    this.maxRequests = RATE_LIMITS.openai.requestsPerMinute;
+    this.maxRequests = RATE_LIMITS[provider].requestsPerMinute;
   }
 
   /**

--- a/packages/services/ai/src/types.ts
+++ b/packages/services/ai/src/types.ts
@@ -38,11 +38,11 @@ export interface ChatCompletionOptions {
  */
 export interface AIResponseMetadata {
   /** Provider that handled the request */
-  provider: 'openai';
+  provider: 'openai' | 'anthropic';
   /** Actual model used (from API response) */
   model: string;
-  /** Which API was used (OpenAI has multiple) */
-  api: 'responses' | 'chat_completions';
+  /** Which API was used */
+  api: 'responses' | 'chat_completions' | 'messages';
   /** Token usage from API response */
   usage?: {
     inputTokens: number | null;


### PR DESCRIPTION
Closes #32.

Rewrites the "Your Week in Music" `/insights` summary for a warmer, music-reacting voice and moves it onto Claude Sonnet 5.

## What changed
- **New `AnthropicClient`** (raw `fetch`, `/v1/messages`) behind the existing `ChatClient` seam; `anthropic` provider + rate limits registered; `getClientForTask` switches on `config.provider`.
- **Prompt rewrite:** analyst→friend persona that reacts to the music with an opinion; the "Do NOT" wall cut to two structural bans (no "not X but Y" anywhere; ≤3 em dashes); atmosphere framing dropped; hand-authored few-shot examples (one paired input→output + two voice-only), all in the owner's voice.
- **Model:** `userInsightsSummary` → `claude-sonnet-5`. Sonnet 5 rejects `temperature` (verified live — 400 "temperature is deprecated for this model"), so the adapter omits sampling params for it; warmth comes from the persona + few-shot, not a temperature dial.
- **Cache-bust:** `v2` prompt version threaded through the cache get/set/delete.
- `ANTHROPIC_API_KEY` wired into web + discord-bot bindings; prod secret set on `listentomore-web`.

## Testing
- 97 web tests + 16 discord-bot tests pass; typechecks clean across web / config / ai / discord-bot.
- Built via TDD, one commit per task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)